### PR TITLE
Add step_duration option to stdout exporter (issue #27)

### DIFF
--- a/docs/exporters/stdout.md
+++ b/docs/exporters/stdout.md
@@ -28,5 +28,5 @@ As always exporter's options can be displayed with `-h`:
         -V, --version    Prints version information
 
     OPTIONS:
-	    -s, --step <step_duration>    Set measurement step duration in second. [default: 2]
-        -t, --timeout <timeout>       Maximum time spent measuring, in seconds. [default: 10]
+    -s, --step <step_duration>    Set measurement step duration in seconds. [default: 2]
+    -t, --timeout <timeout>       Maximum time spent measuring, in seconds. [default: 10]

--- a/docs/exporters/stdout.md
+++ b/docs/exporters/stdout.md
@@ -10,10 +10,14 @@ Default behavior is to measure and show metrics periodically during 10 seconds. 
 
     scaphandre stdout -t 60
 
+You can change as well the step measure duration with -s. Here is how to display metrics during one minutes with a 5s step:
+
+    scaphandre stdout -t 60 -s 5
+
 As always exporter's options can be displayed with `-h`:
 
 	$ scaphandre stdout -h
-    scaphandre-stdout 
+    scaphandre-stdout
     Stdout exporter allows you to output the power consumption data in the terminal.
 
     USAGE:
@@ -24,4 +28,5 @@ As always exporter's options can be displayed with `-h`:
         -V, --version    Prints version information
 
     OPTIONS:
-        -t, --timeout <timeout>    Maximum time spent measuring, in seconds. [default: 10]
+	    -s, --step <step_duration>    Set measurement step duration in second. [default: 2]
+        -t, --timeout <timeout>       Maximum time spent measuring, in seconds. [default: 10]

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -30,6 +30,17 @@ impl Exporter for StdoutExporter {
                 help: String::from("Maximum time spent measuring, in seconds."),
             },
         );
+        options.insert(
+            String::from("step_duration"),
+            ExporterOption {
+                default_value: String::from("2"),
+                long: String::from("step"),
+                short: String::from("s"),
+                required: false,
+                takes_value: true,
+                help: String::from("Set measurement step duration in second."),
+            },
+        );
         options
     }
 }
@@ -52,14 +63,20 @@ impl StdoutExporter {
             let now = Instant::now();
 
             let timeout_secs: u64 = timeout.parse().unwrap();
-            let step = 2;
 
-            println!("Measurement step is: {}s", step);
+            // We have a default value of 2s so it is safe to unwrap the option
+            // Panic if a non numerical value is passed
+            let step_duration: u64 = parameters
+                .value_of("step_duration")
+                .unwrap()
+                .parse()
+                .expect("Wrong step_duration value, should be a number of seconds");
+
+            println!("Measurement step is: {}s", step_duration);
 
             while now.elapsed().as_secs() <= timeout_secs {
-                //self.iteration(step);
                 self.iterate();
-                thread::sleep(Duration::new(step, 0));
+                thread::sleep(Duration::new(step_duration, 0));
             }
         }
     }


### PR DESCRIPTION
@bpetit, please let me know if you want a different description or switches.
Error handling is maybe a bit brutal by making a panic if the value passed is not a numeric one.
