### PR TITLE
Make init.sh more robust

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,9 +1,49 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
-WHOAMI=$(whoami)
+declare -rl PARAM1=${1-null}
+# shellcheck disable=SC2155
+declare -rl SCRIPT_NAME=$(basename "${0}")
+# shellcheck disable=SC2155
+declare -rl DIR_NAME=$(dirname "${0}")
+# shellcheck disable=SC2155
+declare -r CURDIR=$(pwd)
+# shellcheck disable=SC2155
+declare -r WHOAMI=$(whoami)
 
-for i in $(find /sys/devices/virtual/powercap -name energy_uj)
-do
-  sudo chown root:${WHOAMI} ${i}
-  sudo chmod g+r -R ${i}
-done
+usage() {
+  echo "${SCRIPT_NAME} usage:"
+  echo ""
+  echo "${SCRIPT_NAME} [-h|--help]"
+  echo ""
+  echo "-h:     Display this usage"
+  echo "--help: Display this usage"
+  echo ""
+  echo "This script change group ownership and rights of the powercap"
+  echo "special files. So you can run scaphandre as a regular user and"
+  echo "access power data."
+  exit 1
+}
+
+check_parameters() {
+  if [[ ${PARAM1} == '-h' ]] || [[ ${PARAM1} == '--help' ]]; then
+    usage
+  fi
+}
+
+change_power_sf_group_owner_and_rights() {
+  while IFS= read -r -d '' file; do
+    sudo chown root:"${WHOAMI}" "${file}"
+    sudo chmod g+r -R "${file}"
+  done < <(find /sys/devices/virtual/powercap -name energy_uj -print0)
+}
+
+main() {
+  cd "${DIR_NAME}"
+  check_parameters
+  change_power_sf_group_owner_and_rights
+  cd "${CURDIR}"
+}
+
+main


### PR DESCRIPTION
- Follow shellcheck advises. In particular:
  https://github.com/koalaman/shellcheck/wiki/SC2044
- Use strict mode.
- Use read only vars.
- Add a short usage.
- Use explicit functions
- Some stuffs are not useful now, but may help later.