### PR TITLE
fix: Latest failed tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Cargo.lock
 
 # Avoid code coverage and perf data files
 *.data
+
+# Used by integration tests
+/integration_tests

--- a/src/sensors/powercap_rapl.rs
+++ b/src/sensors/powercap_rapl.rs
@@ -130,7 +130,7 @@ mod tests {
         let mut sensor = PowercapRAPLSensor::new(1, 1, false);
         let topology = sensor.get_topology();
         assert_eq!(
-            "alloc::boxed::Box<core::option::Option<&scaphandre::sensors::Topology>>",
+            "alloc::boxed::Box<core::option::Option<scaphandre::sensors::Topology>>",
             type_of(topology)
         )
     }

--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -18,6 +18,7 @@ impl ProcessTracker {
     /// ```
     /// // 5 will be the maximum number of ProcessRecord instances
     /// // stored for each PID.
+    /// use scaphandre::sensors::utils::ProcessTracker;
     /// let tracker = ProcessTracker::new(5);
     /// ```
     pub fn new(max_records_per_process: u16) -> ProcessTracker {
@@ -33,9 +34,11 @@ impl ProcessTracker {
     /// # Example:
     /// ```
     /// use procfs::process::Process;
-    /// let tracker = ProcessTracker::new(5);
+    /// use scaphandre::sensors::utils::ProcessTracker;
+    /// let mut tracker = ProcessTracker::new(5);
+    /// let pid = 1;
     /// if let Ok(result) = tracker.add_process_record(
-    ///     Process::new()
+    ///     Process::new(pid).unwrap()
     /// ){
     ///     println!("ProcessRecord stored successfully: {}", result);
     /// }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,4 @@
-use clap::App;
-use scaphandre::exporters::{qemu::QemuExporter, Exporter};
+use scaphandre::exporters::qemu::QemuExporter;
 use scaphandre::sensors::powercap_rapl::PowercapRAPLSensor;
 use std::fs;
 
@@ -7,13 +6,8 @@ use std::fs;
 fn exporter_qemu() {
     let sensor = PowercapRAPLSensor::new(1, 1, false);
     let mut exporter = QemuExporter::new(Box::new(sensor));
-    let parameters = App::new("scaphandre").get_matches();
-    //exporter.run(parameters);
     let path = "/var/lib/libvirt/scaphandre/integration_tests";
     exporter.iteration(String::from(path));
     let content = fs::read_dir(path);
     assert_eq!(content.is_ok(), true);
-    //for subfolder in content.unwrap() {
-    //
-    //}
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,13 +1,21 @@
 use scaphandre::exporters::qemu::QemuExporter;
 use scaphandre::sensors::powercap_rapl::PowercapRAPLSensor;
-use std::fs;
+use std::env::current_dir;
+use std::fs::{create_dir, read_dir};
 
 #[test]
 fn exporter_qemu() {
     let sensor = PowercapRAPLSensor::new(1, 1, false);
     let mut exporter = QemuExporter::new(Box::new(sensor));
-    let path = "/var/lib/libvirt/scaphandre/integration_tests";
-    exporter.iteration(String::from(path));
-    let content = fs::read_dir(path);
+    // Create integration_tests directory if it does not exist
+    let curdir = current_dir().unwrap();
+    let path = curdir.join("integration_tests");
+    if !path.is_dir() {
+        create_dir(&path).expect("Fail to create integration_tests directory");
+    }
+    // Convert to std::string::String
+    let path = path.into_os_string().to_str().unwrap().to_string();
+    exporter.iteration(path.clone());
+    let content = read_dir(path);
     assert_eq!(content.is_ok(), true);
 }


### PR DESCRIPTION
@bpetit, I wish you a happy new year ! :tada: 

* All tests and doctests should now run fine using `cargo test`.
* No more warning as well.
* Remove few "dead code".
* Create integration_tests directory if it does not exist.

_Note: as I changed a little the doctests, documentation needs to be regenerated and pushed if needed._

So `cargo test` is fully clean. Even if it is a little thing, I like this because it gives some kind of confidence on the project to new comers
```
running 15 tests
test sensors::tests::get_proc_cpuinfo ... ok
test sensors::tests::read_socket_stats ... ok
test sensors::tests::read_topology_stats ... ok
test sensors::units::tests::joule_equals_1000000microjoules ... ok
test sensors::units::tests::joule_to_milijoules ... ok
test sensors::units::tests::kw_equals_0001megawatt ... ok
test sensors::units::tests::kw_equals_1000w ... ok
test sensors::units::tests::kw_to_milliwatt ... ok
test sensors::units::tests::milijoule_to_joules ... ok
test sensors::units::tests::megawatt_to_microwatt ... ok
test sensors::units::tests::milliwatt_to_watt ... ok
test sensors::utils::tests::process_records_cleaned ... ok
test sensors::utils::tests::process_records_added ... ok
test sensors::tests::read_core_stats ... ok
test sensors::powercap_rapl::tests::get_topology_returns_topology_type ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/scaphandre-837a89c522665b5f

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/integration-2fc570143307fa3f

running 1 test
test exporter_qemu ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests scaphandre

running 3 tests
test src/sensors/utils.rs - sensors::utils::ProcessTracker::new (line 18) ... ok
test src/sensors/mod.rs - sensors::Topology::generate_cpu_cores (line 139) ... ok
test src/sensors/utils.rs - sensors::utils::ProcessTracker::add_process_record (line 35) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

```