### PR TITLE
feat: Add --qemu option to prometheus exporter

### DIFF
--- a/docs/exporters/prometheus.md
+++ b/docs/exporters/prometheus.md
@@ -9,25 +9,29 @@ You can launch the prometheus exporter this way (running the default powercap_ra
 	scaphandre prometheus
 
 As always exporter's options can be displayed with `-h`:
-
+```
 	scaphandre prometheus -h
-	scaphandre-prometheus 
-	prometheus exporter exposes power consumption metrics on an http endpoint (/metrics is default) in prometheus accepted
-	format.
+	scaphandre-prometheus
+	Prometheus exporter exposes power consumption metrics on an http endpoint (/metrics is default) in prometheus accepted
+	format
 
 	USAGE:
-		scaphandre --sensor <sensor> prometheus [OPTIONS]
+		scaphandre prometheus [FLAGS] [OPTIONS]
 
 	FLAGS:
 		-h, --help       Prints help information
+		-q, --qemu       Instruct that scaphandre is running on an hypervisor
 		-V, --version    Prints version information
 
 	OPTIONS:
 		-a, --address <address>    ipv6 or ipv4 address to expose the service to [default: ::]
 		-p, --port <port>          TCP port number to expose the service [default: 8080]
 		-s, --suffix <suffix>      url suffix to access metrics [default: metrics]
-
+```
 With default options values, the metrics are exposed on http://localhost:8080/metrics.
+
+Use -q or --qemu option if you are running scaphandre on a hypervisor. In that case a label with the vm name will be added to all `qemu-system*` processes.
+This will allow to easily create charts consumption for each vm and defined which one is the top contributor.
 
 ## Metrics exposed
 

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -23,7 +23,7 @@ pub struct ExporterOption {
     /// Does the option need a value to be specified ?
     pub takes_value: bool,
     /// The default value, if needed
-    pub default_value: String,
+    pub default_value: Option<String>,
     /// One letter to identify the option (useful for the CLI)
     pub short: String,
     /// A word to identify the option

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -516,7 +516,7 @@ fn filter_qemu_cmdline(cmdline: &str) -> Option<String> {
     if cmdline.contains("qemu-system") && cmdline.contains("guest=") {
         let vmname: Vec<Vec<&str>> = cmdline
             .split("guest=")
-            .map(|x| x.split(",").collect())
+            .map(|x| x.split(',').collect())
             .collect();
 
         match (vmname[1].len(), vmname[1][0].is_empty()) {

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -22,7 +22,7 @@ impl Exporter for StdoutExporter {
         options.insert(
             String::from("timeout"),
             ExporterOption {
-                default_value: String::from("10"),
+                default_value: Some(String::from("10")),
                 long: String::from("timeout"),
                 short: String::from("t"),
                 required: false,
@@ -33,7 +33,7 @@ impl Exporter for StdoutExporter {
         options.insert(
             String::from("step_duration"),
             ExporterOption {
-                default_value: String::from("2"),
+                default_value: Some(String::from("2")),
                 long: String::from("step"),
                 short: String::from("s"),
                 required: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,14 +66,24 @@ fn main() {
         );
 
         for (key, opt) in exporters_options.get(exp).unwrap().iter() {
-            let arg = Arg::with_name(key)
-                .required(opt.required)
-                .takes_value(opt.takes_value)
-                .default_value(&opt.default_value)
-                .short(&opt.short)
-                .long(&opt.long)
-                .help(&opt.help);
-            subcmd = subcmd.arg(arg);
+            if let Some(default_value) = &opt.default_value {
+                let arg = Arg::with_name(key)
+                    .required(opt.required)
+                    .takes_value(opt.takes_value)
+                    .default_value(default_value)
+                    .short(&opt.short)
+                    .long(&opt.long)
+                    .help(&opt.help);
+                subcmd = subcmd.arg(arg);
+            } else {
+                let arg = Arg::with_name(key)
+                    .required(opt.required)
+                    .takes_value(opt.takes_value)
+                    .short(&opt.short)
+                    .long(&opt.long)
+                    .help(&opt.help);
+                subcmd = subcmd.arg(arg);
+            }
         }
         matches = matches.subcommand(subcmd);
     }


### PR DESCRIPTION
The prometheus exporter --qemu option extract vmname and expose it.