### PR TITLE
docs(docker): mount `/sys/class/powercap` and `/proc` read-only

### DIFF
--- a/docs_src/tutorials/quickstart.md
+++ b/docs_src/tutorials/quickstart.md
@@ -2,7 +2,7 @@
 
 To quickly run scaphandre in your terminal you may use [docker](https://www.docker.com/):
 
-    docker run -v /sys/class/powercap:/sys/class/powercap -v /proc:/proc -ti hubblo/scaphandre stdout -t 15
+    docker run -v /sys/class/powercap:/sys/class/powercap:ro -v /proc:/proc:ro -ti hubblo/scaphandre stdout -t 15
 
 Or if you downloaded or built a [binary](https://github.com/hubblo-org/scaphandre/releases/latest/download/scaphandre-v0.1.1-Ubuntu_20.04-x86_64.gz), you'd run:
 
@@ -34,7 +34,7 @@ At that point, you're ready to use scaphandre. The Stdout exporter is very basic
 
 The [prometheus exporter](references/exporter-prometheus.md), for example, allows you to expose power consumption metrics as an HTTP endpoint that can be scrapped by a [prometheus](https://prometheus.io) instance:
 
-    docker run -v /sys/class/powercap:/sys/class/powercap -v /proc:/proc -p 8080:8080 -ti hubblo/scaphandre prometheus
+    docker run -v /sys/class/powercap:/sys/class/powercap:ro -v /proc:/proc:ro -p 8080:8080 -ti hubblo/scaphandre prometheus
 
 Here is the same command with a simple binary:
 


### PR DESCRIPTION
Hi! Really cool tool!

Here is a small suggestion: it's probably "better" to mount `/sys/class/powercap` and `/proc`  in containter `ro`