### PR TITLE
feat: Bump dependencies version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ clap = "2.33.3"
 regex = "1"
 procfs = "0.8.1"
 actix-web = "3"
-riemann_client = "0.7.0"
+riemann_client = "0.8.0"
 hostname = "0.3.1"
-protobuf = "^1.0.0"
+protobuf = "2.20.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = "2.33.3"
 regex = "1"
 procfs = "0.8.1"
 actix-web = "3"
-riemann_client = "0.8.0"
+riemann_client = "0.9.0"
 hostname = "0.3.1"
 protobuf = "2.20.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Bump version to the updated riemann-client. (https://github.com/borntyping/rust-riemann_client/pull/6 and https://github.com/borntyping/rust-riemann_client/pull/7)

- Bump riemann client to 0.9.0
- Bump protobuff to 2.20.0