### PR TITLE
feat/refactor_args

### DIFF
--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -2,7 +2,6 @@ use crate::exporters::*;
 use crate::sensors::{Sensor, Topology};
 use clap::Arg;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::path::PathBuf;
@@ -23,56 +22,7 @@ impl Exporter for JSONExporter {
     }
 
     /// Returns options needed for that exporter, as a HashMap
-    fn get_options() -> HashMap<String, ExporterOption> {
-        let mut options = HashMap::new();
-        options.insert(
-            String::from("timeout"),
-            ExporterOption {
-                default_value: Some(String::from("10")),
-                long: String::from("timeout"),
-                short: String::from("t"),
-                required: false,
-                takes_value: true,
-                help: String::from("Maximum time spent measuring, in seconds."),
-            },
-        );
-        options.insert(
-            String::from("step_duration"),
-            ExporterOption {
-                default_value: Some(String::from("2")),
-                long: String::from("step"),
-                short: String::from("s"),
-                required: false,
-                takes_value: true,
-                help: String::from("Set measurement step duration in second."),
-            },
-        );
-        options.insert(
-            String::from("step_duration_nano"),
-            ExporterOption {
-                default_value: Some(String::from("0")),
-                long: String::from("step_nano"),
-                short: String::from("n"),
-                required: false,
-                takes_value: true,
-                help: String::from("Set measurement step duration in nano second."),
-            },
-        );
-        options.insert(
-            String::from("file_path"),
-            ExporterOption {
-                default_value: Some(String::from("")),
-                long: String::from("file"),
-                short: String::from("f"),
-                required: false,
-                takes_value: true,
-                help: String::from("Destination file for the report."),
-            },
-        );
-        options
-    }
-
-    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+    fn get_options() -> Vec<clap::Arg<'static, 'static>> {
         let mut options = Vec::new();
         let arg = Arg::with_name("timeout")
             .default_value("10")

--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -70,6 +70,10 @@ impl Exporter for JSONExporter {
         );
         options
     }
+
+    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+        todo!();
+    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -1,5 +1,6 @@
 use crate::exporters::*;
 use crate::sensors::{Sensor, Topology};
+use clap::Arg;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -72,7 +73,44 @@ impl Exporter for JSONExporter {
     }
 
     fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
-        todo!();
+        let mut options = Vec::new();
+        let arg = Arg::with_name("timeout")
+            .default_value("10")
+            .help("Maximum time spent measuring, in seconds.")
+            .long("timeout")
+            .short("t")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("step_duration")
+            .default_value("2")
+            .help("Set measurement step duration in second.")
+            .long("step")
+            .short("s")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("step_duration_nano")
+            .default_value("0")
+            .help("Set measurement step duration in nano second.")
+            .long("step_nano")
+            .short("n")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("file_path")
+            .default_value("")
+            .help("Destination file for the report.")
+            .long("file")
+            .short("f")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        options
     }
 }
 

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -75,6 +75,7 @@ pub trait Exporter {
     fn run(&mut self, parameters: ArgMatches);
     /// Get the options passed via the command line
     fn get_options() -> HashMap<String, ExporterOption>;
+    fn get_options_new() -> Vec<clap::Arg<'static, 'static>>;
 }
 
 pub struct ExporterOption {

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -74,23 +74,7 @@ pub trait Exporter {
     /// Entry point for all Exporters
     fn run(&mut self, parameters: ArgMatches);
     /// Get the options passed via the command line
-    fn get_options() -> HashMap<String, ExporterOption>;
-    fn get_options_new() -> Vec<clap::Arg<'static, 'static>>;
-}
-
-pub struct ExporterOption {
-    /// States whether the option is mandatory or not
-    pub required: bool,
-    /// Does the option need a value to be specified ?
-    pub takes_value: bool,
-    /// The default value, if needed
-    pub default_value: Option<String>,
-    /// One letter to identify the option (useful for the CLI)
-    pub short: String,
-    /// A word to identify the option
-    pub long: String,
-    /// A brief description to explain what the option does
-    pub help: String,
+    fn get_options() -> Vec<clap::Arg<'static, 'static>>;
 }
 
 /// MetricGenerator is an exporter helper structure to collect Scaphandre metrics.

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -7,6 +7,7 @@ use crate::exporters::*;
 use crate::sensors::{Sensor, Topology};
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
 use chrono::Utc;
+use clap::Arg;
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Mutex;
@@ -107,7 +108,43 @@ impl Exporter for PrometheusExporter {
     }
 
     fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
-        todo!();
+        let mut options = Vec::new();
+        let arg = Arg::with_name("address")
+            .default_value(DEFAULT_IP_ADDRESS)
+            .help("ipv6 or ipv4 address to expose the service to")
+            .long("address")
+            .short("a")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("port")
+            .default_value("8080")
+            .help("TCP port number to expose the service")
+            .long("port")
+            .short("p")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("suffix")
+            .default_value("metrics")
+            .help("url suffix to access metrics")
+            .long("suffix")
+            .short("s")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("qemu")
+            .help("Instruct that scaphandre is running on an hypervisor")
+            .long("qemu")
+            .short("q")
+            .required(false)
+            .takes_value(false);
+        options.push(arg);
+
+        options
     }
 }
 

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -105,6 +105,10 @@ impl Exporter for PrometheusExporter {
 
         options
     }
+
+    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+        todo!();
+    }
 }
 
 /// Contains a mutex holding a Topology object.

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -56,58 +56,7 @@ impl Exporter for PrometheusExporter {
         }
     }
     /// Returns options understood by the exporter.
-    fn get_options() -> HashMap<String, ExporterOption> {
-        let mut options = HashMap::new();
-
-        options.insert(
-            String::from("address"),
-            ExporterOption {
-                default_value: Some(String::from(DEFAULT_IP_ADDRESS)),
-                help: String::from("ipv6 or ipv4 address to expose the service to"),
-                long: String::from("address"),
-                short: String::from("a"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("port"),
-            ExporterOption {
-                default_value: Some(String::from("8080")),
-                help: String::from("TCP port number to expose the service"),
-                long: String::from("port"),
-                short: String::from("p"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("suffix"),
-            ExporterOption {
-                default_value: Some(String::from("metrics")),
-                help: String::from("url suffix to access metrics"),
-                long: String::from("suffix"),
-                short: String::from("s"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("qemu"),
-            ExporterOption {
-                default_value: None,
-                help: String::from("Instruct that scaphandre is running on an hypervisor"),
-                long: String::from("qemu"),
-                short: String::from("q"),
-                required: false,
-                takes_value: false,
-            },
-        );
-
-        options
-    }
-
-    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+    fn get_options() -> Vec<clap::Arg<'static, 'static>> {
         let mut options = Vec::new();
         let arg = Arg::with_name("address")
             .default_value(DEFAULT_IP_ADDRESS)

--- a/src/exporters/qemu.rs
+++ b/src/exporters/qemu.rs
@@ -1,6 +1,5 @@
 use crate::exporters::Exporter;
 use crate::sensors::{utils::ProcessRecord, Sensor, Topology};
-use std::collections::HashMap;
 use std::{fs, io, thread, time};
 
 /// An Exporter that extracts power consumption data of running
@@ -35,11 +34,7 @@ impl Exporter for QemuExporter {
         }
     }
 
-    fn get_options() -> HashMap<String, super::ExporterOption> {
-        HashMap::new()
-    }
-
-    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+    fn get_options() -> Vec<clap::Arg<'static, 'static>> {
         Vec::new()
     }
 }

--- a/src/exporters/qemu.rs
+++ b/src/exporters/qemu.rs
@@ -38,6 +38,10 @@ impl Exporter for QemuExporter {
     fn get_options() -> HashMap<String, super::ExporterOption> {
         HashMap::new()
     }
+
+    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+        Vec::new()
+    }
 }
 
 impl QemuExporter {

--- a/src/exporters/riemann.rs
+++ b/src/exporters/riemann.rs
@@ -211,58 +211,7 @@ impl Exporter for RiemannExporter {
     }
 
     /// Returns options understood by the exporter.
-    fn get_options() -> HashMap<String, ExporterOption> {
-        let mut options = HashMap::new();
-
-        options.insert(
-            String::from("address"),
-            ExporterOption {
-                default_value: Some(String::from(DEFAULT_IP_ADDRESS)),
-                help: String::from("Riemann ipv6 or ipv4 address"),
-                long: String::from("address"),
-                short: String::from("a"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("port"),
-            ExporterOption {
-                default_value: Some(String::from(DEFAULT_PORT)),
-                help: String::from("Riemann TCP port number"),
-                long: String::from("port"),
-                short: String::from("p"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("dispatch_duration"),
-            ExporterOption {
-                default_value: Some(String::from("5")),
-                help: String::from("Duration between metrics dispatch"),
-                long: String::from("dispatch"),
-                short: String::from("d"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("qemu"),
-            ExporterOption {
-                default_value: None,
-                help: String::from("Instruct that scaphandre is running on an hypervisor"),
-                long: String::from("qemu"),
-                short: String::from("q"),
-                required: false,
-                takes_value: false,
-            },
-        );
-
-        options
-    }
-
-    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+    fn get_options() -> Vec<clap::Arg<'static, 'static>> {
         let mut options = Vec::new();
         let arg = Arg::with_name("address")
             .default_value(DEFAULT_IP_ADDRESS)

--- a/src/exporters/riemann.rs
+++ b/src/exporters/riemann.rs
@@ -103,24 +103,6 @@ impl RiemannExporter {
     pub fn new(sensor: Box<dyn Sensor>) -> RiemannExporter {
         RiemannExporter { sensor }
     }
-
-    pub fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
-        let mut options = Vec::new();
-        let arg = Arg::with_name("truc")
-            .required(true)
-            .default_value("bidule")
-            .short("-b")
-            .long("--bidule")
-            .help("This is bidule help");
-        options.push(arg);
-        let arg = Arg::with_name("machin")
-            .required(true)
-            .default_value("supermachin")
-            .long("--machin")
-            .help("This is machin help");
-        options.push(arg);
-        options
-    }
 }
 
 impl Exporter for RiemannExporter {
@@ -276,6 +258,46 @@ impl Exporter for RiemannExporter {
                 takes_value: false,
             },
         );
+
+        options
+    }
+
+    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+        let mut options = Vec::new();
+        let arg = Arg::with_name("address")
+            .default_value(DEFAULT_IP_ADDRESS)
+            .help("Riemann ipv6 or ipv4 address")
+            .long("address")
+            .short("a")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("port")
+            .default_value(DEFAULT_PORT)
+            .help("Riemann TCP port number")
+            .long("port")
+            .short("p")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("dispatch_duration")
+            .default_value("5")
+            .help("Duration between metrics dispatch")
+            .long("dispatch")
+            .short("d")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("qemu")
+            .help("Instruct that scaphandre is running on an hypervisor")
+            .long("qemu")
+            .short("q")
+            .required(false)
+            .takes_value(false);
+        options.push(arg);
 
         options
     }

--- a/src/exporters/riemann.rs
+++ b/src/exporters/riemann.rs
@@ -6,6 +6,7 @@ use crate::exporters::utils::get_hostname;
 use crate::exporters::*;
 use crate::sensors::Sensor;
 use chrono::Utc;
+use clap::Arg;
 use riemann_client::proto::Attribute;
 use riemann_client::proto::Event;
 use riemann_client::Client;
@@ -101,6 +102,24 @@ impl RiemannExporter {
     /// Returns a RiemannExporter instance.
     pub fn new(sensor: Box<dyn Sensor>) -> RiemannExporter {
         RiemannExporter { sensor }
+    }
+
+    pub fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+        let mut options = Vec::new();
+        let arg = Arg::with_name("truc")
+            .required(true)
+            .default_value("bidule")
+            .short("-b")
+            .long("--bidule")
+            .help("This is bidule help");
+        options.push(arg);
+        let arg = Arg::with_name("machin")
+            .required(true)
+            .default_value("supermachin")
+            .long("--machin")
+            .help("This is machin help");
+        options.push(arg);
+        options
     }
 }
 

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -19,34 +19,7 @@ impl Exporter for StdoutExporter {
     }
 
     /// Returns options needed for that exporter, as a HashMap
-    fn get_options() -> HashMap<String, ExporterOption> {
-        let mut options = HashMap::new();
-        options.insert(
-            String::from("timeout"),
-            ExporterOption {
-                default_value: Some(String::from("10")),
-                long: String::from("timeout"),
-                short: String::from("t"),
-                required: false,
-                takes_value: true,
-                help: String::from("Maximum time spent measuring, in seconds."),
-            },
-        );
-        options.insert(
-            String::from("step_duration"),
-            ExporterOption {
-                default_value: Some(String::from("2")),
-                long: String::from("step"),
-                short: String::from("s"),
-                required: false,
-                takes_value: true,
-                help: String::from("Set measurement step duration in second."),
-            },
-        );
-        options
-    }
-
-    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+    fn get_options() -> Vec<clap::Arg<'static, 'static>> {
         let mut options = Vec::new();
         let arg = Arg::with_name("timeout")
             .default_value("10")

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -1,3 +1,5 @@
+use clap::Arg;
+
 use crate::exporters::*;
 use crate::sensors::{Record, Sensor, Topology};
 use std::collections::HashMap;
@@ -45,7 +47,26 @@ impl Exporter for StdoutExporter {
     }
 
     fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
-        todo!();
+        let mut options = Vec::new();
+        let arg = Arg::with_name("timeout")
+            .default_value("10")
+            .help("Maximum time spent measuring, in seconds.")
+            .long("timeout")
+            .short("t")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("step_duration")
+            .default_value("2")
+            .help("Set measurement step duration in second.")
+            .long("step")
+            .short("s")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        options
     }
 }
 

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -43,6 +43,10 @@ impl Exporter for StdoutExporter {
         );
         options
     }
+
+    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+        todo!();
+    }
 }
 
 impl StdoutExporter {

--- a/src/exporters/warpten.rs
+++ b/src/exporters/warpten.rs
@@ -1,7 +1,6 @@
 use crate::exporters::*;
 use crate::sensors::{RecordGenerator, Sensor, Topology};
 use clap::Arg;
-use std::collections::HashMap;
 use std::time::Duration;
 use std::{env, thread};
 use utils::get_scaphandre_version;
@@ -52,91 +51,7 @@ impl Exporter for Warp10Exporter {
     }
 
     /// Options for configuring the exporter.
-    fn get_options() -> HashMap<String, super::ExporterOption> {
-        let mut options = HashMap::new();
-
-        options.insert(
-            String::from("host"),
-            ExporterOption {
-                default_value: Some(String::from("localhost")),
-                help: String::from("Warp10 host's FQDN or IP address to send data to"),
-                long: String::from("host"),
-                short: String::from("H"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("scheme"),
-            ExporterOption {
-                default_value: Some(String::from("http")),
-                help: String::from("Either 'http' or 'https'"),
-                long: String::from("scheme"),
-                short: String::from("s"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("port"),
-            ExporterOption {
-                default_value: Some(String::from("8080")),
-                help: String::from("TCP port to join Warp10 on the host"),
-                long: String::from("port"),
-                short: String::from("p"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("write-token"),
-            ExporterOption {
-                default_value: None,
-                help: String::from("Auth. token to write on Warp10"),
-                long: String::from("write-token"),
-                short: String::from("t"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        //options.insert(
-        //    String::from("read-token"),
-        //    ExporterOption {
-        //        default_value: None,
-        //        help: String::from("Auth. token to read on Warp10"),
-        //        long: String::from("read-token"),
-        //        short: String::from("r"),
-        //        required: false,
-        //        takes_value: true,
-        //    },
-        //);
-        options.insert(
-            String::from("step"),
-            ExporterOption {
-                default_value: Some(String::from("30")),
-                help: String::from("Time step between measurements, in seconds."),
-                long: String::from("step"),
-                short: String::from("S"),
-                required: false,
-                takes_value: true,
-            },
-        );
-        options.insert(
-            String::from("qemu"),
-            ExporterOption {
-                default_value: None,
-                help: String::from("Tells scaphandre it is running on a Qemu hypervisor."),
-                long: String::from("qemu"),
-                short: String::from("q"),
-                required: false,
-                takes_value: false,
-            },
-        );
-
-        options
-    }
-
-    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+    fn get_options() -> Vec<clap::Arg<'static, 'static>> {
         let mut options = Vec::new();
         let arg = Arg::with_name("host")
             .default_value("localhost")

--- a/src/exporters/warpten.rs
+++ b/src/exporters/warpten.rs
@@ -134,6 +134,10 @@ impl Exporter for Warp10Exporter {
 
         options
     }
+
+    fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
+        todo!();
+    }
 }
 
 impl Warp10Exporter {

--- a/src/exporters/warpten.rs
+++ b/src/exporters/warpten.rs
@@ -1,5 +1,6 @@
 use crate::exporters::*;
 use crate::sensors::{RecordGenerator, Sensor, Topology};
+use clap::Arg;
 use std::collections::HashMap;
 use std::time::Duration;
 use std::{env, thread};
@@ -136,7 +137,60 @@ impl Exporter for Warp10Exporter {
     }
 
     fn get_options_new() -> Vec<clap::Arg<'static, 'static>> {
-        todo!();
+        let mut options = Vec::new();
+        let arg = Arg::with_name("host")
+            .default_value("localhost")
+            .help("Warp10 host's FQDN or IP address to send data to")
+            .long("host")
+            .short("H")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("scheme")
+            .default_value("http")
+            .help("Either 'http' or 'https'")
+            .long("scheme")
+            .short("s")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("port")
+            .default_value("8080")
+            .help("TCP port to join Warp10 on the host")
+            .long("port")
+            .short("p")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("write-token")
+            .help("Auth. token to write on Warp10")
+            .long("write-token")
+            .short("t")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("step")
+            .default_value("30")
+            .help("Time step between measurements, in seconds.")
+            .long("step")
+            .short("S")
+            .required(false)
+            .takes_value(true);
+        options.push(arg);
+
+        let arg = Arg::with_name("qemu")
+            .help("Tells scaphandre it is running on a Qemu hypervisor.")
+            .long("qemu")
+            .short("q")
+            .required(false)
+            .takes_value(false);
+        options.push(arg);
+
+        options
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,10 +150,10 @@ pub fn get_exporters_options_new() -> HashMap<String, Vec<clap::Arg<'static, 'st
         String::from("json"),
         exporters::json::JSONExporter::get_options_new(),
     );
-    // options.insert(
-    //     String::from("prometheus"),
-    //     exporters::prometheus::PrometheusExporter::get_options_new(),
-    // );
+    options.insert(
+        String::from("prometheus"),
+        exporters::prometheus::PrometheusExporter::get_options_new(),
+    );
     options.insert(
         String::from("riemann"),
         exporters::riemann::RiemannExporter::get_options_new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,10 +142,10 @@ pub fn get_exporters_options() -> HashMap<String, HashMap<String, ExporterOption
 
 pub fn get_exporters_options_new() -> HashMap<String, Vec<clap::Arg<'static, 'static>>> {
     let mut options = HashMap::new();
-    // options.insert(
-    //     String::from("stdout"),
-    //     exporters::stdout::StdoutExporter::get_options_new(),
-    // );
+    options.insert(
+        String::from("stdout"),
+        exporters::stdout::StdoutExporter::get_options_new(),
+    );
     // options.insert(
     //     String::from("json"),
     //     exporters::json::JSONExporter::get_options_new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,10 +162,10 @@ pub fn get_exporters_options_new() -> HashMap<String, Vec<clap::Arg<'static, 'st
         String::from("qemu"),
         exporters::qemu::QemuExporter::get_options_new(),
     );
-    // options.insert(
-    //     String::from("warp10"),
-    //     exporters::warpten::Warp10Exporter::get_options_new(),
-    // );
+    options.insert(
+        String::from("warp10"),
+        exporters::warpten::Warp10Exporter::get_options_new(),
+    );
     options
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,10 +158,10 @@ pub fn get_exporters_options_new() -> HashMap<String, Vec<clap::Arg<'static, 'st
         String::from("riemann"),
         exporters::riemann::RiemannExporter::get_options_new(),
     );
-    // options.insert(
-    //     String::from("qemu"),
-    //     exporters::qemu::QemuExporter::get_options_new(),
-    // );
+    options.insert(
+        String::from("qemu"),
+        exporters::qemu::QemuExporter::get_options_new(),
+    );
     // options.insert(
     //     String::from("warp10"),
     //     exporters::warpten::Warp10Exporter::get_options_new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,10 +142,30 @@ pub fn get_exporters_options() -> HashMap<String, HashMap<String, ExporterOption
 
 pub fn get_exporters_options_new() -> HashMap<String, Vec<clap::Arg<'static, 'static>>> {
     let mut options = HashMap::new();
+    // options.insert(
+    //     String::from("stdout"),
+    //     exporters::stdout::StdoutExporter::get_options_new(),
+    // );
+    // options.insert(
+    //     String::from("json"),
+    //     exporters::json::JSONExporter::get_options_new(),
+    // );
+    // options.insert(
+    //     String::from("prometheus"),
+    //     exporters::prometheus::PrometheusExporter::get_options_new(),
+    // );
     options.insert(
         String::from("riemann"),
         exporters::riemann::RiemannExporter::get_options_new(),
     );
+    // options.insert(
+    //     String::from("qemu"),
+    //     exporters::qemu::QemuExporter::get_options_new(),
+    // );
+    // options.insert(
+    //     String::from("warp10"),
+    //     exporters::warpten::Warp10Exporter::get_options_new(),
+    // );
     options
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,15 @@ pub fn get_exporters_options() -> HashMap<String, HashMap<String, ExporterOption
     options
 }
 
+pub fn get_exporters_options_new() -> HashMap<String, Vec<clap::Arg<'static, 'static>>> {
+    let mut options = HashMap::new();
+    options.insert(
+        String::from("riemann"),
+        exporters::riemann::RiemannExporter::get_options_new(),
+    );
+    options
+}
+
 fn current_system_time_since_epoch() -> Duration {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,10 +146,10 @@ pub fn get_exporters_options_new() -> HashMap<String, Vec<clap::Arg<'static, 'st
         String::from("stdout"),
         exporters::stdout::StdoutExporter::get_options_new(),
     );
-    // options.insert(
-    //     String::from("json"),
-    //     exporters::json::JSONExporter::get_options_new(),
-    // );
+    options.insert(
+        String::from("json"),
+        exporters::json::JSONExporter::get_options_new(),
+    );
     // options.insert(
     //     String::from("prometheus"),
     //     exporters::prometheus::PrometheusExporter::get_options_new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use colored::*;
 use exporters::{
     json::JSONExporter, prometheus::PrometheusExporter, qemu::QemuExporter,
     riemann::RiemannExporter, stdout::StdoutExporter, warpten::Warp10Exporter, Exporter,
-    ExporterOption,
 };
 use sensors::{powercap_rapl::PowercapRAPLSensor, Sensor};
 use std::collections::HashMap;
@@ -111,7 +110,7 @@ pub fn run(matches: ArgMatches) {
 
 /// Returns options needed for each exporter as a HashMap.
 /// This function has to be updated to enable a new exporter.
-pub fn get_exporters_options() -> HashMap<String, HashMap<String, ExporterOption>> {
+pub fn get_exporters_options() -> HashMap<String, Vec<clap::Arg<'static, 'static>>> {
     let mut options = HashMap::new();
     options.insert(
         String::from("stdout"),
@@ -136,35 +135,6 @@ pub fn get_exporters_options() -> HashMap<String, HashMap<String, ExporterOption
     options.insert(
         String::from("warp10"),
         exporters::warpten::Warp10Exporter::get_options(),
-    );
-    options
-}
-
-pub fn get_exporters_options_new() -> HashMap<String, Vec<clap::Arg<'static, 'static>>> {
-    let mut options = HashMap::new();
-    options.insert(
-        String::from("stdout"),
-        exporters::stdout::StdoutExporter::get_options_new(),
-    );
-    options.insert(
-        String::from("json"),
-        exporters::json::JSONExporter::get_options_new(),
-    );
-    options.insert(
-        String::from("prometheus"),
-        exporters::prometheus::PrometheusExporter::get_options_new(),
-    );
-    options.insert(
-        String::from("riemann"),
-        exporters::riemann::RiemannExporter::get_options_new(),
-    );
-    options.insert(
-        String::from("qemu"),
-        exporters::qemu::QemuExporter::get_options_new(),
-    );
-    options.insert(
-        String::from("warp10"),
-        exporters::warpten::Warp10Exporter::get_options_new(),
     );
     options
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@ use scaphandre::{get_exporters_options, get_exporters_options_new, run};
 fn main() {
     let sensors = ["powercap_rapl"];
     let exporters_options = get_exporters_options();
+    let exporters = exporters_options.keys();
+    let exporters: Vec<&str> = exporters.into_iter().map(|x| x.as_str()).collect();
     let exporters_options_new = get_exporters_options_new();
     let exporters_new = exporters_options_new.keys();
     dbg!(exporters_new);
-    let exporters = exporters_options.keys();
-    let exporters: Vec<&str> = exporters.into_iter().map(|x| x.as_str()).collect();
 
     let mut matches = App::new("scaphandre")
         .author("Benoit Petit <bpetit@hubblo.org>")
@@ -76,28 +76,31 @@ fn main() {
             }
         );
 
-        let myopts = exporters_options_new.get("riemann").unwrap().clone();
-        for opt in myopts {
-            subcmd = subcmd.arg(opt);
-        }
-        for (key, opt) in exporters_options.get(exporter).unwrap().iter() {
-            if let Some(default_value) = &opt.default_value {
-                let arg = Arg::with_name(key)
-                    .required(opt.required)
-                    .takes_value(opt.takes_value)
-                    .default_value(default_value)
-                    .short(&opt.short)
-                    .long(&opt.long)
-                    .help(&opt.help);
-                subcmd = subcmd.arg(arg);
-            } else {
-                let arg = Arg::with_name(key)
-                    .required(opt.required)
-                    .takes_value(opt.takes_value)
-                    .short(&opt.short)
-                    .long(&opt.long)
-                    .help(&opt.help);
-                subcmd = subcmd.arg(arg);
+        if exporter == "riemann" {
+            let myopts = exporters_options_new.get(exporter).unwrap();
+            for opt in myopts {
+                subcmd = subcmd.arg(opt);
+            }
+        } else {
+            for (key, opt) in exporters_options.get(exporter).unwrap().iter() {
+                if let Some(default_value) = &opt.default_value {
+                    let arg = Arg::with_name(key)
+                        .required(opt.required)
+                        .takes_value(opt.takes_value)
+                        .default_value(default_value)
+                        .short(&opt.short)
+                        .long(&opt.long)
+                        .help(&opt.help);
+                    subcmd = subcmd.arg(arg);
+                } else {
+                    let arg = Arg::with_name(key)
+                        .required(opt.required)
+                        .takes_value(opt.takes_value)
+                        .short(&opt.short)
+                        .long(&opt.long)
+                        .help(&opt.help);
+                    subcmd = subcmd.arg(arg);
+                }
             }
         }
         matches = matches.subcommand(subcmd);

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,7 @@ fn main() {
             || exporter == "json"
             || exporter == "prometheus"
             || exporter == "qemu"
+            || exporter == "warp10"
         {
             let myopts = exporters_options_new.get(exporter).unwrap();
             for opt in myopts {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
             }
         );
 
-        if exporter == "riemann" || exporter == "stdout" {
+        if exporter == "riemann" || exporter == "stdout" || exporter == "json" {
             let myopts = exporters_options_new.get(exporter).unwrap();
             for opt in myopts {
                 subcmd = subcmd.arg(opt);

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
             }
         );
 
-        if exporter == "riemann" {
+        if exporter == "riemann" || exporter == "stdout" {
             let myopts = exporters_options_new.get(exporter).unwrap();
             for opt in myopts {
                 subcmd = subcmd.arg(opt);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
 //! Generic sensor and transmission agent for energy consumption related metrics.
 use clap::{crate_version, App, AppSettings, Arg, SubCommand};
-use scaphandre::{get_exporters_options, get_exporters_options_new, run};
+use scaphandre::{get_exporters_options, run};
 fn main() {
     let sensors = ["powercap_rapl"];
     let exporters_options = get_exporters_options();
     let exporters = exporters_options.keys();
     let exporters: Vec<&str> = exporters.into_iter().map(|x| x.as_str()).collect();
-    let exporters_options_new = get_exporters_options_new();
-    let exporters_new = exporters_options_new.keys();
-    dbg!(exporters_new);
 
     let mut matches = App::new("scaphandre")
         .author("Benoit Petit <bpetit@hubblo.org>")
@@ -76,38 +73,9 @@ fn main() {
             }
         );
 
-        if exporter == "riemann"
-            || exporter == "stdout"
-            || exporter == "json"
-            || exporter == "prometheus"
-            || exporter == "qemu"
-            || exporter == "warp10"
-        {
-            let myopts = exporters_options_new.get(exporter).unwrap();
-            for opt in myopts {
-                subcmd = subcmd.arg(opt);
-            }
-        } else {
-            for (key, opt) in exporters_options.get(exporter).unwrap().iter() {
-                if let Some(default_value) = &opt.default_value {
-                    let arg = Arg::with_name(key)
-                        .required(opt.required)
-                        .takes_value(opt.takes_value)
-                        .default_value(default_value)
-                        .short(&opt.short)
-                        .long(&opt.long)
-                        .help(&opt.help);
-                    subcmd = subcmd.arg(arg);
-                } else {
-                    let arg = Arg::with_name(key)
-                        .required(opt.required)
-                        .takes_value(opt.takes_value)
-                        .short(&opt.short)
-                        .long(&opt.long)
-                        .help(&opt.help);
-                    subcmd = subcmd.arg(arg);
-                }
-            }
+        let myopts = exporters_options.get(exporter).unwrap();
+        for opt in myopts {
+            subcmd = subcmd.arg(opt);
         }
         matches = matches.subcommand(subcmd);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,11 @@ fn main() {
             }
         );
 
-        if exporter == "riemann" || exporter == "stdout" || exporter == "json" {
+        if exporter == "riemann"
+            || exporter == "stdout"
+            || exporter == "json"
+            || exporter == "prometheus"
+        {
             let myopts = exporters_options_new.get(exporter).unwrap();
             for opt in myopts {
                 subcmd = subcmd.arg(opt);

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ fn main() {
             || exporter == "stdout"
             || exporter == "json"
             || exporter == "prometheus"
+            || exporter == "qemu"
         {
             let myopts = exporters_options_new.get(exporter).unwrap();
             for opt in myopts {


### PR DESCRIPTION
- **Refactor completed.**
- This will be useful/needed for Riemann mTLS.
- **Goal is to define args on the exporters to allow a maximum
  flexibility. (usage of various options like group options etc...)**
- Avoid the code in main to choose between args with default values and
  no default values as this is not flexible at all.
```rust
 if let Some(default_value) = &opt.default_value {
                let arg = Arg::with_name(key)
                    .required(opt.required)
                    .takes_value(opt.takes_value)
                    .default_value(default_value)
                    .short(&opt.short)
                    .long(&opt.long)
                    .help(&opt.help);
                subcmd = subcmd.arg(arg);
            } else {
                let arg = Arg::with_name(key)
                    .required(opt.required)
                    .takes_value(opt.takes_value)
                    .short(&opt.short)
                    .long(&opt.long)
                    .help(&opt.help);
                subcmd = subcmd.arg(arg);
            }
```
* All help outputs have been checked and are identical as the ones before the refactoring.