### PR TITLE
docs: fixing dead link and typos

### DIFF
--- a/docs_src/README.md
+++ b/docs_src/README.md
@@ -4,7 +4,7 @@
 
 Welcome on [Scaphandre](https://github.com/hubblo-org/scaphandre) documentation.
 
-Scaphandre is a **monitoring agent**, dedicated to **energy consumption** metrics. It's purpose is to help measuring and thus understanding tech services energy consumption patterns. This is key, in our opinion, to enable the tech industry to shift towards more sustainability. 💚
+Scaphandre is a **monitoring agent**, dedicated to **energy consumption** metrics. Its purpose is to help measuring and thus understanding tech services energy consumption patterns. This is key, in our opinion, to enable the tech industry to shift towards more sustainability. 💚
 
 If at this point you think "why bother ?", or if you want more details about this project's motivations, please have a look at the [why](why.md) section.
 
@@ -12,6 +12,6 @@ If not and you want to proceed, just directly jump to the [tutorials](tutorials/
 
 If you need more in-depth, use-case oriented instructions, the [how-to guides](how-to_guides/propagate-metrics-hypervisor-to-vm_qemu-kvm.md) are here for you.
 
-[Explanations](section) is about theoritical concepts behind scaphandre and the reasons for the technical choices that have been made so far.
+[Explanations](explanations/how-scaph-computes-per-process-power-consumption.md) is about theoretical concepts behind scaphandre and the reasons for the technical choices that have been made so far.
 
 If you are already using, hacking or exploring scaphandre and need precise informations about one of its components, go to the [references](references/exporter-prometheus.md) section. (The code documentation itself is [here](https://docs.rs/scaphandre/)).

--- a/docs_src/compatibility.md
+++ b/docs_src/compatibility.md
@@ -6,7 +6,7 @@ To summarize, scaphandre should provide two ways to estimate the power consumpti
 
 In scaphandre, the code responsible to collect the power consumption data before any further processing is grouped in components called **sensors**. If you want more details about scaphandre structure, [here are the explanations](explanations/internal-structure.md).
 
-The [PowercapRAPL sensor](references/sensor-powercap_rapl.md) enables you to measure the power consumption, it is the most precise solution, but it doesn't work in all contexts. A future sensor is to be developped to support other use cases. Here is the current state of scaphandre's compatibility:
+The [PowercapRAPL sensor](references/sensor-powercap_rapl.md) enables you to measure the power consumption, it is the most precise solution, but it doesn't work in all contexts. A future sensor is to be developed to support other use cases. Here is the current state of scaphandre's compatibility:
 
 | Sensor         | Intel x86 bare metal | AMD x86 bare metal | ARM bare metal | Virtual Machine | Public cloud instance | Container |
 | :------------- | :------------------: | :----------------: | :------------: | :-------------: | :-------------------: | :-------: |

--- a/docs_src/contributing.md
+++ b/docs_src/contributing.md
@@ -20,9 +20,9 @@ This project intends to unite a lot of people to have a lot of positive impact. 
 Discussions and questions about the project are welcome on [gitter](https://gitter.im/hubblo-org/scaphandre?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) or by [email](mailto://bpetit@hubblo.org?Subject=About%20Scaphandre).
 ### Contribution guidelines
 
-This project intends to use [conventionnal commit messages](https://conventionalcommits.org/) and the [gitflow](https://nvie.com/posts/a-successful-git-branching-model/) workflow.
+This project intends to use [conventional commit messages](https://conventionalcommits.org/) and the [gitflow](https://nvie.com/posts/a-successful-git-branching-model/) workflow.
 
-Scaphandre is a not only a tool, but a framework. Modules dedicated to collect energy comsumption data from the host are called [**Sensors**](docs/sensors).
+Scaphandre is a not only a tool, but a framework. Modules dedicated to collect energy consumption data from the host are called [**Sensors**](docs/sensors).
 Modules that are dedicated to send this data to a given channel or remote system are called [**Exporters**](docs/exporters). New Sensors and Exporters are going to be created and all contributions are welcome. For more on the internal structure please jump [here](explanations/internal-structure.md).
 
 ### Edit and build the documentation

--- a/docs_src/explanations/how-scaph-computes-per-process-power-consumption.md
+++ b/docs_src/explanations/how-scaph-computes-per-process-power-consumption.md
@@ -15,7 +15,7 @@ This is easy to understand, and it matches how we might be billed for a share of
 
 #### Timesharing of work
 
-However, if the reality was _exactly_ like this diagram, our computers would only ever be able to do sonething at a time. It's more accurate and helpful to think of computers working on lots of different jobs at the same time - they work on one job for short interval of time, then another, and another and so one. You'll often see these [small intervals of time referred to as _[jiffies][]_.
+However, if the reality was _exactly_ like this diagram, our computers would only ever be able to do something at a time. It's more accurate and helpful to think of computers working on lots of different jobs at the same time - they work on one job for short interval of time, then another, and another and so one. You'll often see these [small intervals of time referred to as _[jiffies][]_.
 
 [jiffies]: https://www.anshulpatel.in/post/linux_cpu_percentage/
 
@@ -65,7 +65,7 @@ However, if a guest virtual machine or guest container _does_ have access to rea
 As you can see with the [prometheus exporter reference](../references/exporter-prometheus.md), scaphandre exporters can provide process level power consumption metrics. This section will explain how it is done and how it may be improved in the future.
 ## Some details about RAPL
 
-We'll talk here about the case where scaphandre is able to effectively measure the power consumption of the host (see [compatibility](../compatibility.md) section for more on sensors and their prerequesites) and specifically about the [PowercapRAPL](../references/sensor-powercap_rapl.md) sensor.
+We'll talk here about the case where scaphandre is able to effectively measure the power consumption of the host (see [compatibility](../compatibility.md) section for more on sensors and their prerequisites) and specifically about the [PowercapRAPL](../references/sensor-powercap_rapl.md) sensor.
 
 Let's clarify what's happening when you collect metrics with scaphandre and this sensor.
 RAPL stands for [Running Average Power Limit](https://01.org/blogs/2014/running-average-power-limit-%E2%80%93-rapl). It's a technnology embedded in most Intel and AMD x86 CPUs produced after 2012.
@@ -86,6 +86,6 @@ With those data it is possible to compute the ratio of CPU time actively spent f
 
 ### How to get the consumption of an application/a service ?
 
-Services and programs are often not running only one PID. It's needed to aggregate the consumption of all related PIDs to know what this service is actually consuming. 
+Services and programs are often not running only one PID. It's needed to aggregate the consumption of all related PIDs to know what this service is actually consuming.
 
 To do that, in the current state of scaphandre development, you can use the Prometheus exporter, and then use Prometheus TSDB and query language capabilities. You'll find examples looking at the graphs and queries [here](https://metrics.hubblo.org). In a near future, more advanced features may be implemented in scaphandre to allow such classification even if you don't have access to a proper TSDB.


### PR DESCRIPTION
Hi, fixed a broken link to _Explanations_ section on doc home page + minor typos.