### PR TITLE
Fix/domain order

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,0 +1,7 @@
+@software{scaphandre,
+  author       = {Benoit Petit},
+  title        = {scaphandre},
+  year         = 2021,
+  version      = {v0.2},
+  url          = {https://github.com/hubblo-org/scaphandre}
+}

--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::path::PathBuf;
 use std::thread;
 use std::time::{Duration, Instant};
+use crate::current_system_time_since_epoch;
 
 /// An Exporter that displays power consumption data of the host
 /// and its processes on the standard output of the terminal.
@@ -68,6 +69,17 @@ impl Exporter for JSONExporter {
                 help: String::from("Destination file for the report."),
             },
         );
+        options.insert(
+            String::from("max_top_consumers"),
+            ExporterOption {
+                default_value: Some(String::from("10")),
+                long: String::from("max-top-consumers"),
+                short: String::from("m"),
+                required: false,
+                takes_value: true,
+                help: String::from("Maximum number of processes to watch.")
+            }
+        );
         options
     }
 }
@@ -91,8 +103,13 @@ struct Consumer {
     consumption: f32,
 }
 #[derive(Serialize, Deserialize)]
+struct Host {
+    consumption: f32,
+    timestamp: f64
+}
+#[derive(Serialize, Deserialize)]
 struct Report {
-    host: f32,
+    host: Host,
     consumers: Vec<Consumer>,
     sockets: Vec<Socket>,
 }
@@ -145,18 +162,25 @@ impl JSONExporter {
     }
 
     fn retrieve_metrics(&mut self, parameters: &ArgMatches) {
-        let host_power = self
+        let mut host_power = 0;
+        let host_timestamp: Duration;
+        if let Some(microwatts_record) = self
             .topology
-            .get_records_diff_power_microwatts()
-            .map(|record| record.value.parse::<u64>().unwrap())
-            .unwrap_or(0);
-
+            .get_records_diff_power_microwatts() {
+            host_timestamp = microwatts_record.timestamp;
+        
+            host_power =
+                microwatts_record.value.parse::<u64>().unwrap();
+        } else {
+            host_timestamp = current_system_time_since_epoch();
+        }
+        
         let host_stat = match self.topology.get_stats_diff() {
             Some(value) => value,
             None => return,
         };
 
-        let consumers = self.topology.proc_tracker.get_top_consumers(10);
+        let consumers = self.topology.proc_tracker.get_top_consumers(parameters.value_of("max_top_consumers").unwrap_or("10").parse::<u16>().unwrap());
         let top_consumers = consumers
             .iter()
             .map(|(process, value)| {
@@ -205,9 +229,14 @@ impl JSONExporter {
                 }
             })
             .collect::<Vec<_>>();
+        
+        let host_report = Host {
+            consumption: host_power as f32,
+            timestamp: host_timestamp.as_secs_f64()
+        };
 
         let report = Report {
-            host: host_power as f32,
+            host: host_report,
             consumers: top_consumers,
             sockets: all_sockets,
         };

--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -70,7 +70,7 @@ impl Exporter for JSONExporter {
             .required(false)
             .takes_value(true);
         options.push(arg);
-      
+
         options
     }
 }

--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -189,7 +189,7 @@ impl JSONExporter {
             })
             .collect::<Vec<_>>();
 
-        let names = ["core", "uncore", "dram"];
+        // let names = ["core", "uncore", "dram"];
         let all_sockets = self
             .topology
             .get_sockets_passive()
@@ -203,14 +203,13 @@ impl JSONExporter {
                 let domains = socket
                     .get_domains_passive()
                     .iter()
-                    .map(|d| d.get_records_diff_power_microwatts())
-                    .map(|record| record.map(|d| d.value))
-                    .enumerate()
-                    .map(|(index, d)| {
+                    .map(|d| (d.name.clone(), d.get_records_diff_power_microwatts()))
+                    .map(|(n, record)| (n, record.map(|d| d.value)))
+                    .map(|(name, d)| {
                         let domain_power =
                             d.map(|value| value.parse::<u64>().unwrap()).unwrap_or(0);
                         Domain {
-                            name: names[index].to_string(),
+                            name: name,
                             consumption: domain_power as f32,
                         }
                     })

--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -209,7 +209,7 @@ impl JSONExporter {
                         let domain_power =
                             d.map(|value| value.parse::<u64>().unwrap()).unwrap_or(0);
                         Domain {
-                            name: name,
+                            name,
                             consumption: domain_power as f32,
                         }
                     })

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -121,11 +121,7 @@ impl StdoutExporter {
         }
         let domain_names = self.topology.domains_names.as_ref().unwrap();
 
-        println!(
-            "Host:\t{} W",
-            (host_power as f32 / 1000000.0)
-            
-        );
+        println!("Host:\t{} W", (host_power as f32 / 1000000.0));
         println!("\tpackage \t{}", domain_names.join("\t\t"));
 
         for (s_id, v) in sockets_power.iter() {

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -79,7 +79,8 @@ impl StdoutExporter {
         }
     }
 
-    fn get_domains_power(&self, socket_id: u16) -> Vec<Option<Record>> {
+    // Retuns the power for each domain in a socket.
+    fn get_domains_power(&self, socket_id: u16) -> HashMap<String, Option<Record>> {
         let socket_present = self
             .topology
             .get_sockets_passive()
@@ -87,13 +88,14 @@ impl StdoutExporter {
             .find(move |x| x.id == socket_id);
 
         if let Some(socket) = socket_present {
-            let mut domains_power: Vec<Option<Record>> = vec![];
+            // let mut domains_power: Vec<Option<Record>> = vec![];
+            let mut domains_power: HashMap<String, Option<Record>> = HashMap::new();
             for d in socket.get_domains_passive() {
-                domains_power.push(d.get_records_diff_power_microwatts());
+                domains_power.insert(d.name.clone(), d.get_records_diff_power_microwatts());
             }
             domains_power
         } else {
-            vec![None, None, None]
+            HashMap::new()
         }
     }
 
@@ -107,7 +109,8 @@ impl StdoutExporter {
             Some(record) => record.value.parse::<u64>().unwrap(),
             None => 0,
         };
-        let mut sockets_power: HashMap<u16, (u64, Vec<Option<Record>>)> = HashMap::new();
+        let mut sockets_power: HashMap<u16, (u64, HashMap<String, Option<Record>>)> =
+            HashMap::new();
         let sockets = self.topology.get_sockets_passive();
         for s in sockets {
             let socket_power = match s.get_records_diff_power_microwatts() {
@@ -116,26 +119,39 @@ impl StdoutExporter {
             };
             sockets_power.insert(s.id, (socket_power, self.get_domains_power(s.id)));
         }
+        let domain_names = self.topology.domains_names.as_ref().unwrap();
+
         println!(
-            "Host:\t{} W\tCore\t\tUncore\t\tDRAM",
+            "Host:\t{} W",
             (host_power as f32 / 1000000.0)
+            
         );
+        println!("\tpackage \t{}", domain_names.join("\t\t"));
+
         for (s_id, v) in sockets_power.iter() {
             let power = (v.0 as f32) / 1000000.0;
-            let mut power_str = String::from('?');
+            let mut power_str = String::from("----");
             if power > 0.0 {
                 power_str = power.to_string();
             }
+
             let mut to_print = format!("Socket{}\t{} W\t", s_id, power_str);
-            for d in v.1.iter() {
-                let domain_power = match d {
-                    Some(record) => record.value.parse::<u64>().unwrap(),
-                    None => 0,
-                };
-                to_print.push_str(&format!("{} W\t", domain_power as f32 / 1000000.0));
+
+            for domain in domain_names.iter() {
+                if let Some(Some(record)) = v.1.get(domain) {
+                    to_print.push_str(&format!(
+                        "{} W\t",
+                        record.value.parse::<u64>().unwrap() as f32 / 1000000.0
+                    ));
+                } else {
+                    // This should only happen when we don't have yet enough records,
+                    // as in a multi-sockets system, all sockets have the same domains.
+                    to_print.push_str("---- \t\t");
+                }
             }
             println!("{}", to_print);
         }
+
         println!("Top 5 consumers:");
         println!("Power\tPID\tExe");
 

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -196,6 +196,19 @@ impl Topology {
         &self.sockets
     }
 
+    // Returns a sorted list of all domains names from all sockets.
+    pub fn get_domains_names(&self) -> Vec<String> {
+        let mut names: HashMap<String, ()> = HashMap::new();
+        for s in self.sockets.iter() {
+            for d in s.get_domains_passive() {
+                names.insert(d.name.clone(), ());
+            }
+        }
+        let mut domain_names = names.keys().cloned().collect::<Vec<String>>();
+        domain_names.sort();
+        domain_names
+    }
+
     /// Adds a Domain instance to a given socket, if and only if the domain
     /// id doesn't exist already for the socket.
     pub fn safe_add_domain_to_socket(

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -643,7 +643,7 @@ impl CPUSocket {
         &mut self.domains
     }
 
-    /// Returns a mutable reference to the domains vector.
+    /// Returns a immutable reference to the domains vector.
     pub fn get_domains_passive(&self) -> &Vec<Domain> {
         &self.domains
     }

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -41,6 +41,8 @@ pub struct Topology {
     pub record_buffer: Vec<Record>,
     /// Maximum size in memory for the recor_buffer
     pub buffer_max_kbytes: u16,
+    /// Sorted list of all domains names
+    pub domains_names: Option<Vec<String>>,
 }
 
 impl RecordGenerator for Topology {
@@ -128,6 +130,7 @@ impl Topology {
             stat_buffer: vec![],
             record_buffer: vec![],
             buffer_max_kbytes: 1,
+            domains_names: None,
         }
     }
 
@@ -196,8 +199,8 @@ impl Topology {
         &self.sockets
     }
 
-    // Returns a sorted list of all domains names from all sockets.
-    pub fn get_domains_names(&self) -> Vec<String> {
+    // Build a sorted list of all domains names from all sockets.
+    fn build_domains_names(&mut self) {
         let mut names: HashMap<String, ()> = HashMap::new();
         for s in self.sockets.iter() {
             for d in s.get_domains_passive() {
@@ -206,7 +209,7 @@ impl Topology {
         }
         let mut domain_names = names.keys().cloned().collect::<Vec<String>>();
         domain_names.sort();
-        domain_names
+        self.domains_names = Some(domain_names);
     }
 
     /// Adds a Domain instance to a given socket, if and only if the domain
@@ -230,6 +233,7 @@ impl Topology {
                 ));
             }
         }
+        self.build_domains_names();
     }
 
     /// Generates CPUCore instances for the host and adds them


### PR DESCRIPTION
This should fix #108 and ensure that all detected domains are displayed. Let me know what you think.

Before merging, I'm wondering why the 'package' domain is not handled as the other domains ?  Is there any reason I'm missing ? I could try to change that but it would probably have an impact on all other exporters.

Besides, I have yet to check the Json exporter to check if the same fix is needed.