### PR TITLE
feat: add support for containers arg to helm chart

### DIFF
--- a/helm/scaphandre/templates/rbac.yaml
+++ b/helm/scaphandre/templates/rbac.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ template "scaphandre.name" . }}
   labels:
@@ -9,12 +9,12 @@ subjects:
   name: {{ template "scaphandre.name" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: {{ template "scaphandre.name" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ template "scaphandre.name" . }}
   labels:
@@ -28,3 +28,10 @@ rules:
   - {{ .Chart.Name }}
   verbs:
   - "use"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch

--- a/helm/scaphandre/values.yaml
+++ b/helm/scaphandre/values.yaml
@@ -13,7 +13,8 @@ resources:
 
 scaphandre:
   command: prometheus
-  extraArgs: {}
+  extraArgs:
+    containers: true
 
 # Run as root user to get proper permissions
 userID: 0


### PR DESCRIPTION
@bpetit This adds support for the `--containers arg` to the helm chart.

It also extends the RBAC rules for listing pods.