### PR TITLE
fix: support k8s pods using containerd

### DIFF
--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -257,7 +257,9 @@ impl ProcessTracker {
                                         Some(id) => {
                                             if let Some(final_id) = id.strip_prefix("docker://") {
                                                 final_id == container_id
-                                            } else if let Some(final_id) = id.strip_prefix("containerd://") {
+                                            } else if let Some(final_id) =
+                                                id.strip_prefix("containerd://")
+                                            {
                                                 final_id == container_id
                                             } else {
                                                 false


### PR DESCRIPTION
@bpetit This fixes a problem I ran into when I switched to using Cluster API to bootstrap my test clusters.
https://github.com/kubernetes-sigs/cluster-api-provider-packet

The nodes are running containerd and in the pod container statuses it uses `containerd://` instead of `docker://`. 
