### PR TITLE
fix: use ubuntu 20.04 LTS in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=cacher /app/target target
 COPY --from=cacher $CARGO_HOME $CARGO_HOME
 RUN cargo build --release
 
-FROM ubuntu:20.10 as runtime
+FROM ubuntu:21.10 as runtime
 WORKDIR app
 
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=cacher /app/target target
 COPY --from=cacher $CARGO_HOME $CARGO_HOME
 RUN cargo build --release
 
-FROM ubuntu:21.10 as runtime
+FROM ubuntu:20.04 as runtime
 WORKDIR app
 
 RUN apt-get update \


### PR DESCRIPTION
Use latest Ubuntu in docker file as a proposed fix for https://github.com/hubblo-org/scaphandre/issues/150

Alternative could also be to use an older LTS version.

_After merge, docker image may need to be republished as `hubblo/scaphandre:latest`_
