### PR TITLE
Fix missing volume in psp

### DIFF
--- a/helm/scaphandre/templates/psp.yaml
+++ b/helm/scaphandre/templates/psp.yaml
@@ -22,6 +22,7 @@ spec:
       - min: 1
         max: 65535
   volumes:
-  - 'hostPath'
+  - hostPath
+  - projected
   hostPID: true
   hostIPC: true


### PR DESCRIPTION
Hi,  

We tried installing scaphandre on our cluster (baremetal, kubespray, 1.22, docker) using helm and the pods were not being created due to invalid PSP configuration.  
After some investigation, we found out that the daemonset used a `projected` volume and that `projected` volumes were not allowed by the PSP. Adding `projected` volume to the PSP fixes the installation.  

This PR adds `projected` to the list of volumes allowed by the PSP created by Helm