### PR TITLE
fix: Always set last pods check timestamp

### DIFF
--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -598,13 +598,13 @@ impl MetricGenerator {
                 if let Ok(pods_result) = kubernetes.list_pods("".to_string()) {
                     self.pods = pods_result;
                     debug!("Found {} pods", &self.pods.len());
-                    self.pods_last_check = current_system_time_since_epoch().as_secs().to_string();
                 } else {
                     info!("Failed getting pods list, despite client seems ok.");
                 }
             } else {
                 debug!("Kubernetes socket is not some.");
             }
+            self.pods_last_check = current_system_time_since_epoch().as_secs().to_string();
         }
     }
 


### PR DESCRIPTION
Towards https://github.com/hubblo-org/scaphandre/issues/166

If fetching the pods metadata fails `pods_last_check` is not set. This causes an error when checking whether to fetch the metadata again.

```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: ParseIntError { kind: Empty }', src/exporters/mod.rs:653:77
stack backtrace:
```