### PR TITLE
Add dependabot Github file for Rust dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Description
- Setup dependabot for Rust by adding `dependabot.yml` file in the Github configuration
- Weekly frequency to have up-to-date Rust dependencies
- Only on `dev` branch

refers to #180 

# Documentation
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file