### PR TITLE
Addressed issue #133

### DIFF
--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -256,13 +256,22 @@ impl Topology {
                 .unwrap()
                 .parse::<u16>()
                 .unwrap();
-            let socket = self
+            let socket_match = self
                 .sockets
                 .iter_mut()
-                .find(|x| &x.id == socket_id)
-                .expect("Trick: if you are running on a vm, do not forget to use --vm parameter invoking scaphandre at the command line");
+                .find(|x| &x.id == socket_id);
+            
+            //In VMs there might be a missmatch betwen Sockets and Cores - see Issue#133 as a first fix we just map all cores that can't be mapped to the first
+            let socket = match socket_match {
+                Some(x) => x,
+                None =>self.sockets.first_mut().expect("Trick: if you are running on a vm, do not forget to use --vm parameter invoking scaphandre at the command line")
+            };
+
             if socket_id == &socket.id {
                 socket.add_cpu_core(c);
+            } else {
+                socket.add_cpu_core(c);
+                warn!("coud't not match core to socket - mapping to first socket instead - if you are not using --vm there is something wrong")
             }
         }
     }


### PR DESCRIPTION
Hello, while trying to use scaphandre with the qemu I encountered the issue #133. Looking into it a bit more, the reason behind this stems from the way qemu (at least for my setup) handles multi-core/multi-thread CPUs. In essence, instead of allowing you to set core or thread count for the virtual CPU, you add sockets to the VM; see this [stack overflow discussion](https://superuser.com/questions/1577756/qemu-cpu-topology-doesn-t-match-maximum-vcpu-count).  

So to fix this I just fall back to the first socket found by the sensor and add all encountered cores to it. Sorry if the code is ugly, I'm new to rust. Anyway, with this fix, u can use the VM mode even for VM's with more vCores.