### PR TITLE
feat: Add service monitor on helm chart

### DIFF
--- a/docs_src/tutorials/kubernetes.md
+++ b/docs_src/tutorials/kubernetes.md
@@ -12,6 +12,14 @@ to be installed from the source code.
     git clone https://github.com/hubblo-org/scaphandre
     cd scaphandre
     helm install scaphandre helm/scaphandre
+### Parameters
+#### Service monitor parameters
+
+| Name                                       | Description                                                                                                     | Value                     |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                    | `false`                    |
+| `serviceMonitor.namespace`         | The namespace in which the ServiceMonitor will be created   (if not set, default to namespace on which this chart is installed)                                                    | `""`                      |
+| `serviceMonitor.interval`          | The interval at which metrics should be scraped                                                                 | `1m`                     |
 
 ## Install Prometheus
 

--- a/helm/scaphandre/templates/servicemonitor.yaml
+++ b/helm/scaphandre/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "scaphandre.name" . }}-service-monitoring
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "scaphandre.name" . }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+      scheme: http
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "scaphandre.name" . }}
+{{- end }}

--- a/helm/scaphandre/values.yaml
+++ b/helm/scaphandre/values.yaml
@@ -6,10 +6,10 @@ port: 8080
 
 resources:
   limits:
-    memory: 75Mi
+    memory: 200Mi
   requests:
     cpu: 75m
-    memory: 50Mi
+    memory: 100Mi
 
 scaphandre:
   command: prometheus
@@ -21,3 +21,10 @@ scaphandre:
 # Run as root user to get proper permissions
 userID: 0
 groupID: 0
+
+serviceMonitor:
+  # Specifies whether ServiceMonitor for Prometheus operator should be created
+  enabled: false
+  interval: 1m
+  # Specifies namespace, where ServiceMonitor should be installed
+  # namespace: monitoring


### PR DESCRIPTION
Allow configuration of service monitor in order to have metrics collected by an external prometheus

Signed-off-by: Nicolas Trangosi <nicolas.trangosi@dcbrain.com>