### PR TITLE
fix: Don't create PSP if k8s >= 1.25

### DIFF
--- a/helm/scaphandre/templates/psp.yaml
+++ b/helm/scaphandre/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -26,3 +27,4 @@ spec:
   - projected
   hostPID: true
   hostIPC: true
+{{- end }}

--- a/helm/scaphandre/templates/rbac.yaml
+++ b/helm/scaphandre/templates/rbac.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 rules:
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 - apiGroups:
   - extensions
   resources:
@@ -28,6 +29,7 @@ rules:
   - {{ .Chart.Name }}
   verbs:
   - "use"
+{{- end }}
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
@bpetit This is a fix for https://github.com/hubblo-org/scaphandre/issues/246 

I opened it against main but LMK if I should be targeting dev 🙏 