### PR TITLE
Refactor exporter creation with clap v4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,12 +55,12 @@ jobs:
           override: true
           components: rustfmt
       - name: Check formatting
-        uses: rust-cargo-action@v2
+        uses: bpetit/rust-cargo-action@v2
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: rust-cargo-action@v2
+        uses: bpetit/rust-cargo-action@v2
         with:
           command: clippy
           args: -- -A clippy::upper_case_acronyms -D warnings
@@ -79,12 +79,12 @@ jobs:
         run: |
           rustup toolchain install stable-x86_64-pc-windows-msvc
       - name: Check formatting
-        uses: rust-cargo-action@v2
+        uses: bpetit/rust-cargo-action@v2
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: rust-cargo-action@v2
+        uses: bpetit/rust-cargo-action@v2
         with:
           command : clippy
           args: --no-default-features --features "prometheus json riemann"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,19 +48,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v2
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
           components: rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v2
+        uses: bpetit/action-cargo@v2
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: actions-rs/cargo@v2
+        uses: bpetit/action-cargo@v2
         with:
           command: clippy
           args: -- -A clippy::upper_case_acronyms -D warnings
@@ -79,12 +79,12 @@ jobs:
         run: |
           rustup toolchain install stable-x86_64-pc-windows-msvc
       - name: Check formatting
-        uses: actions-rs/cargo@v2
+        uses: bpetit/action-cargo@v2
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: actions-rs/cargo@v2
+        uses: bpetit/action-cargo@v2
         with:
           command : clippy
           args: --no-default-features --features "prometheus json riemann"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,9 +42,9 @@ jobs:
     needs: check_pr_is_on_the_right_branch
     steps:
       - name: Cancel Previous Runs
-        uses: ambimax/action-cancel-previous-runs@v1
+        uses: ambimax/action-cancel-previous-runs@v2
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -68,7 +68,7 @@ jobs:
     needs: check_pr_is_on_the_right_branch
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rustup
         uses: crazy-max/ghaction-chocolatey@v2
         with:
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies (awxkit)
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
       - name: Install python requirements (awxkit)
@@ -124,7 +124,7 @@ jobs:
       - test_linux_x86_64
     steps:
       - name: Install dependencies (awxkit)
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
       - name: Install python requirements (awxkit)
@@ -157,7 +157,7 @@ jobs:
     runs-on: "windows-2019"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rustup
         uses: crazy-max/ghaction-chocolatey@v2
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,7 +103,7 @@ jobs:
         id: login
         run: |
           export AWX_TOKEN=$(awx --conf.host "${{env.AWX_HOST}}" --conf.username "${{env.AWX_PUBLIC_USER}}" --conf.password "${{env.AWX_PUBLIC_ACCESS}}" login | jq .token | tr -d '"')
-          echo "::set-output name=awx_token::${AWX_TOKEN}"
+          echo "awx_token=${AWX_TOKEN}" >> $GITHUB_OUTPUT
       - name: Prepare Rust environment on bare metal worker
         id: rust
         run: |
@@ -135,7 +135,7 @@ jobs:
         id: login
         run: |
           export AWX_TOKEN=$(awx --conf.host "${{env.AWX_HOST}}" --conf.username "${{env.AWX_PUBLIC_USER}}" --conf.password "${{env.AWX_PUBLIC_ACCESS}}" login | jq .token | tr -d '"')
-          echo "::set-output name=awx_token::${AWX_TOKEN}"
+          echo "awx_token=${AWX_TOKEN}" >> $GITHUB_OUTPUT
       - name: Build debug version
         id: builddebug
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,12 +55,12 @@ jobs:
           override: true
           components: rustfmt
       - name: Check formatting
-        uses: bpetit/rust-cargo-action@v2
+        uses: bpetit/cargo-action@v2.0.1
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: bpetit/rust-cargo-action@v2
+        uses: bpetit/cargo-action@v2.0.1
         with:
           command: clippy
           args: -- -A clippy::upper_case_acronyms -D warnings
@@ -79,12 +79,12 @@ jobs:
         run: |
           rustup toolchain install stable-x86_64-pc-windows-msvc
       - name: Check formatting
-        uses: bpetit/rust-cargo-action@v2
+        uses: bpetit/cargo-action@v2.0.1
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: bpetit/rust-cargo-action@v2
+        uses: bpetit/cargo-action@v2.0.1
         with:
           command : clippy
           args: --no-default-features --features "prometheus json riemann"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,7 +87,7 @@ jobs:
         uses: bpetit/action-cargo@v2.0.1
         with:
           command : clippy
-          args: --no-default-features --features "prometheus json riemann"
+          args: --no-default-features --features "prometheus json riemann warpten"
 
   test_linux_x86_64:
     name: Test on GNU/Linux x86_64 (Bare metal worker)
@@ -169,7 +169,7 @@ jobs:
           rustup toolchain install stable-x86_64-pc-windows-msvc
       - name: Build (debug mode)
         run: |
-          cargo test --no-default-features --features "prometheus json riemann"
+          cargo test --no-default-features --features "prometheus json riemann warpten"
       - name: Build (debug mode)
         run: |
-          cargo build --no-default-features --features "prometheus json riemann"
+          cargo build --no-default-features --features "prometheus json riemann warpten"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: bpetit/action-toolchain@v2.0.0
         with:
           toolchain: stable
           profile: minimal

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,19 +48,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v2
         with:
           toolchain: stable
           profile: minimal
           override: true
           components: rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command: clippy
           args: -- -A clippy::upper_case_acronyms -D warnings
@@ -79,12 +79,12 @@ jobs:
         run: |
           rustup toolchain install stable-x86_64-pc-windows-msvc
       - name: Check formatting
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command : clippy
           args: --no-default-features --features "prometheus json riemann"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,12 +55,12 @@ jobs:
           override: true
           components: rustfmt
       - name: Check formatting
-        uses: bpetit/cargo-action@v2.0.1
+        uses: bpetit/action-cargo@v2.0.1
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: bpetit/cargo-action@v2.0.1
+        uses: bpetit/action-cargo@v2.0.1
         with:
           command: clippy
           args: -- -A clippy::upper_case_acronyms -D warnings
@@ -79,12 +79,12 @@ jobs:
         run: |
           rustup toolchain install stable-x86_64-pc-windows-msvc
       - name: Check formatting
-        uses: bpetit/cargo-action@v2.0.1
+        uses: bpetit/action-cargo@v2.0.1
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: bpetit/cargo-action@v2.0.1
+        uses: bpetit/action-cargo@v2.0.1
         with:
           command : clippy
           args: --no-default-features --features "prometheus json riemann"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,12 +55,12 @@ jobs:
           override: true
           components: rustfmt
       - name: Check formatting
-        uses: bpetit/action-cargo@v2
+        uses: rust-cargo-action@v2
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: bpetit/action-cargo@v2
+        uses: rust-cargo-action@v2
         with:
           command: clippy
           args: -- -A clippy::upper_case_acronyms -D warnings
@@ -79,12 +79,12 @@ jobs:
         run: |
           rustup toolchain install stable-x86_64-pc-windows-msvc
       - name: Check formatting
-        uses: bpetit/action-cargo@v2
+        uses: rust-cargo-action@v2
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy Check
-        uses: bpetit/action-cargo@v2
+        uses: rust-cargo-action@v2
         with:
           command : clippy
           args: --no-default-features --features "prometheus json riemann"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,6 +25,10 @@ env:
   AWX_PUBLIC_USER: "scaphandre-public"
   AWX_HOST: "https://cd.hubblo.org"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_pr_is_on_the_right_branch:
     name: Check PR is open on the right branch
@@ -41,8 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_pr_is_on_the_right_branch
     steps:
-      - name: Cancel Previous Runs
-        uses: ambimax/action-cancel-previous-runs@v2
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Rust

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -136,6 +136,14 @@ jobs:
         run: |
           export AWX_TOKEN=$(awx --conf.host "${{env.AWX_HOST}}" --conf.username "${{env.AWX_PUBLIC_USER}}" --conf.password "${{env.AWX_PUBLIC_ACCESS}}" login | jq .token | tr -d '"')
           echo "::set-output name=awx_token::${AWX_TOKEN}"
+      - name: Build debug version
+        id: builddebug
+        run: |
+          awx --conf.token ${{ steps.login.outputs.awx_token }} --conf.host ${{ env.AWX_HOST }} job_templates launch --extra_vars="{\"github_repository\":\"${GITHUB_REPOSITORY}\",\"github_actor\":\"${GITHUB_ACTOR}\",\"github_workflow\":\"${GITHUB_WORKFLOW}\",\"github_workspace\":\"${GITHUB_WORKSPACE}\",\"github_event_name\":\"${GITHUB_EVENT_NAME}\",\"github_event_path\":\"${GITHUB_EVENT_PATH}\",\"github_sha\":\"${GITHUB_SHA}\",\"github_ref\":\"${GITHUB_REF}\",\"github_head_ref\":\"${GITHUB_HEAD_REF}\",\"github_base_ref\":\"${GITHUB_BASE_REF}\",\"github_server_url\":\"${GITHUB_SERVER_URL}\"}" 17 --monitor
+      - name: Test JSON exporter
+        id: jsonexporter
+        run: |
+          awx --conf.token ${{ steps.login.outputs.awx_token }} --conf.host ${{ env.AWX_HOST }} job_templates launch --extra_vars="{\"github_repository\":\"${GITHUB_REPOSITORY}\",\"github_actor\":\"${GITHUB_ACTOR}\",\"github_workflow\":\"${GITHUB_WORKFLOW}\",\"github_workspace\":\"${GITHUB_WORKSPACE}\",\"github_event_name\":\"${GITHUB_EVENT_NAME}\",\"github_event_path\":\"${GITHUB_EVENT_PATH}\",\"github_sha\":\"${GITHUB_SHA}\",\"github_ref\":\"${GITHUB_REF}\",\"github_head_ref\":\"${GITHUB_HEAD_REF}\",\"github_base_ref\":\"${GITHUB_BASE_REF}\",\"github_server_url\":\"${GITHUB_SERVER_URL}\"}" 18 --monitor
       - name: Build Docker image
         id: dockerbuild
         run: |

--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -56,7 +56,7 @@ jobs:
 
       # We need the rust toolchain because it uses rustc and cargo to inspect the package
       - name: Configure Rust 1.x stable
-        uses: actions-rs/toolchain@v1
+        uses: bpetit/action-toolchain@v2.0.0
         if: ${{ fromJSON(steps.detect-languages.outputs.languages).rust }} 
         with:
           toolchain: stable

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -24,7 +24,7 @@ jobs:
           pip install black isort mypy 
           make check-python
       - name: Install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+        uses: bpetit/action-toolchain@v2.0.0
         with:
           profile: default
           toolchain: stable
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: bpetit/action-toolchain@v2.0.0
         with:
           toolchain: stable
           override: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -36,10 +36,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.7.1"
+name = "anstream"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -52,7 +101,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -77,9 +126,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -89,15 +138,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
-
-[[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "castaway"
@@ -107,9 +150,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -119,42 +162,62 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "clap"
-version = "4.0.19"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e67816e006b17427c9b4386915109b494fec2d929c63e3bd3561234cbf1bf1e"
+checksum = "49f9152d70e42172fdb87de2efd7327160beee37886027cf86f30a233d5b30b4"
 dependencies = [
- "atty",
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e067b220911598876eb55d52725ddcc201ffe3f0904018195973bc5b012ea2ca"
+dependencies = [
+ "anstream",
+ "anstyle",
  "bitflags",
  "clap_lex",
  "once_cell",
  "strsim",
- "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "codespan-reporting"
@@ -165,6 +228,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -179,18 +248,18 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
 dependencies = [
- "cache-padded",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "crc32fast"
@@ -203,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -213,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -224,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -237,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -261,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.59+curl-7.86.0"
+version = "0.4.61+curl-8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfce34829f448b08f55b7db6d0009e23e2e86a34e8c2b366269bf5799b4a407"
+checksum = "14d05c10f541ae6f3bc5b3d923c20001f47db7d5f0b2bc6ad16490133842db79"
 dependencies = [
  "cc",
  "libc",
@@ -277,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -289,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -299,24 +368,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -366,17 +435,38 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -387,18 +477,18 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -436,30 +526,30 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -472,21 +562,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -507,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -518,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -542,6 +632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +645,21 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -569,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -603,9 +714,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.22"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -627,16 +738,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -661,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -676,6 +787,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -709,15 +843,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -766,9 +900,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -794,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -806,6 +940,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
 
 [[package]]
 name = "lock_api"
@@ -851,24 +991,24 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -915,25 +1055,25 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -946,13 +1086,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -963,11 +1103,10 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -984,16 +1123,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
-
-[[package]]
 name = "parking"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
@@ -1013,7 +1146,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -1041,7 +1174,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1064,16 +1197,18 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
-version = "2.4.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
+checksum = "4be1c66a6add46bff50935c313dae30a5030cf8385c5206e8a95e9e9def974aa"
 dependencies = [
  "autocfg",
+ "bitflags",
  "cfg-if",
+ "concurrent-queue",
  "libc",
  "log",
- "wepoll-ffi",
- "winapi",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1084,9 +1219,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -1114,9 +1249,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1164,21 +1299,19 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1196,21 +1329,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
- "redox_syscall",
+ "getrandom 0.2.9",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1219,18 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "riemann_client"
@@ -1264,6 +1397,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.37.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "scaphandre"
@@ -1316,17 +1463,16 @@ dependencies = [
  "time 0.3.20",
  "tokio",
  "warp10",
- "windows",
+ "windows 0.27.0",
 ]
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1337,9 +1483,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -1353,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
@@ -1372,20 +1518,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1406,18 +1552,18 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -1463,9 +1609,20 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1474,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.3"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69e0d827cce279e61c2f3399eb789271a8f136d8245edef70f06e3c9601a670"
+checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -1489,52 +1646,51 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -1568,20 +1724,19 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -1594,20 +1749,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1644,7 +1799,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1668,21 +1823,21 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -1715,6 +1870,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"
@@ -1772,9 +1933,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1782,24 +1943,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1807,28 +1968,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1851,15 +2012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1903,6 +2055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,15 +2078,17 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1934,7 +2097,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1943,13 +2115,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.2",
  "windows_aarch64_msvc 0.42.2",
  "windows_i686_gnu 0.42.2",
  "windows_i686_msvc 0.42.2",
  "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1959,6 +2146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,15 +2159,15 @@ checksum = "ec7d1649bbab232cde71148c6ef7bbe647f214d2154dd66347fada60de40cda7"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1984,15 +2177,15 @@ checksum = "b4eb20b59b93fc302839f3b0df3e61de7e9606b44cb54cbeb68d71cf137309fa"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2002,15 +2195,15 @@ checksum = "40331d8ef3e4dcdc8982eb7de16e1f09b86f5384626a56b3a99c2a51b88ff98e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2020,21 +2213,27 @@ checksum = "5937d290e39c3308147d9b877c5fa741c50f4121ea78d2d20c4a138ad365464a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2044,15 +2243,15 @@ checksum = "dee1b76aec4e2bead4758a181b663c37af0de7ec56fe6837c10215b8d6a1635f"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.3"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f9152d70e42172fdb87de2efd7327160beee37886027cf86f30a233d5b30b4"
+checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.3"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e067b220911598876eb55d52725ddcc201ffe3f0904018195973bc5b012ea2ca"
+checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
 dependencies = [
  "anstream",
  "anstyle",
@@ -808,7 +808,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.13",
  "windows-sys 0.48.0",
 ]
 
@@ -900,9 +900,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -943,9 +943,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "lock_api"
@@ -1027,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
 ]
@@ -1071,9 +1077,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1103,9 +1109,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
 dependencies = [
  "cc",
  "libc",
@@ -1197,9 +1203,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be1c66a6add46bff50935c313dae30a5030cf8385c5206e8a95e9e9def974aa"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
  "bitflags",
@@ -1228,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.12.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0941606b9934e2d98a3677759a971756eb821f75764d0e0d26946d08e74d9104"
+checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -1238,7 +1244,7 @@ dependencies = [
  "flate2",
  "hex",
  "lazy_static",
- "libc",
+ "rustix 0.36.12",
 ]
 
 [[package]]
@@ -1350,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "ac6cf59af1067a3fb53fbe5c88c053764e930f932be1d71d3ffe032cbe147f59"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1361,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "b6868896879ba532248f33598de5181522d8b3d9d724dfd230911e1a7d4822f5"
 
 [[package]]
 name = "riemann_client"
@@ -1398,15 +1404,29 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.12"
+version = "0.36.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
+checksum = "e0af200a3324fa5bcd922e84e9b55a298ea9f431a489f01961acdebc6e908f25"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.3",
  "windows-sys 0.48.0",
 ]
 
@@ -1653,7 +1673,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.13",
  "windows-sys 0.45.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "scaphandre"
 version = "0.5.0"
 authors = ["Benoit Petit <bpetit@hubblo.org>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Electrical power consumption measurement agent."
 repository = "https://github.com/hubblo-org/scaphandre"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ procfs = { version = "0.15.0" }
 windows = { version = "0.27.0", features = ["alloc","Win32_Storage_FileSystem","Win32_Foundation","Win32_Security","Win32_System_IO","Win32_System_Ioctl"]}
 
 [features]
-default = ["prometheus", "riemann", "warpten", "json", "containers", "qemu"]
+default = ["prometheus", "riemann", "warpten", "json", "containers"]
 prometheus = ["hyper", "tokio"]
 riemann = ["riemann_client"]
 json = ["serde", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,7 @@ homepage = "https://hubblo-org.github.io/scaphandre-documentation"
 [dependencies]
 loggerv = "0.7.2"
 log = "0.4"
-# clap string feature is required to allow dynamic values otherwise it ended up with a lifetime pb.
-# https://docs.rs/clap/4.0.19/clap/builder/struct.Str.html
-clap = { version = "4.0.18", features = ["cargo", "string"] }
+clap = { version = "4.2", features = ["cargo", "derive"] }
 regex = "1.7.0"
 riemann_client = { version = "0.9.0", optional = true }
 hostname = "0.3.1"
@@ -43,9 +41,10 @@ procfs = { version = "0.12.0" }
 windows = { version = "0.27.0", features = ["alloc","Win32_Storage_FileSystem","Win32_Foundation","Win32_Security","Win32_System_IO","Win32_System_Ioctl"]}
 
 [features]
-default = ["prometheus", "riemann", "warpten", "json", "containers"]
+default = ["prometheus", "riemann", "warpten", "json", "containers", "qemu"]
 prometheus = ["hyper", "tokio"]
 riemann = ["riemann_client"]
 json = ["serde", "serde_json"]
 containers = ["docker-sync", "k8s-sync"]
 warpten = ["warp10"]
+qemu = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ homepage = "https://hubblo-org.github.io/scaphandre-documentation"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-loggerv = "0.7.2"
+loggerv = "0.7"
 log = "0.4"
 clap = { version = "4.2", features = ["cargo", "derive"] }
-regex = "1.7.0"
+regex = "1.7"
 riemann_client = { version = "0.9.0", optional = true }
 hostname = "0.3.1"
 protobuf = "2.28.0"
@@ -24,9 +24,9 @@ serde_json = { version = "1.0", optional = true }
 ordered-float = "2.0"
 warp10 = { version = "2.0.0", optional = true }
 rand = { version = "0.7.3" }
-time = "0.3.20"
-colored = "2.0.0"
-chrono = "0.4.19"
+time = "0.3"
+colored = "2.0"
+chrono = "0.4"
 docker-sync = { version = "0.1.2", optional = true }
 k8s-sync = { version = "0.2.3", optional = true }
 hyper = { version = "0.14", features = ["full"], optional = true }
@@ -34,8 +34,7 @@ tokio = { version = "1.26.0", features = ["full"], optional = true}
 sysinfo = { version = "0.28.3"}
 
 [target.'cfg(target_os="linux")'.dependencies]
-#procfs = "0.13.2"
-procfs = { version = "0.12.0" }
+procfs = { version = "0.15.0" }
 
 [target.'cfg(target_os="windows")'.dependencies]
 windows = { version = "0.27.0", features = ["alloc","Win32_Storage_FileSystem","Win32_Foundation","Win32_Security","Win32_System_IO","Win32_System_Ioctl"]}

--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -347,7 +347,6 @@ impl JsonExporter {
 
             #[cfg(not(feature = "containers"))]
             {
-                info!("Container regex filter is used but containers feature is not present. Returning top consumers based on max-top-consumers.");
                 self.metric_generator
                     .topology
                     .proc_tracker

--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -345,7 +345,8 @@ impl JsonExporter {
                     .get_processes_filtered_by_container_name(regex_filter)
             }
 
-            #[cfg(not(feature = "containers"))]{
+            #[cfg(not(feature = "containers"))]
+            {
                 info!("Container regex filter is used but containers feature is not present. Returning top consumers based on max-top-consumers.");
                 self.metric_generator
                     .topology

--- a/src/exporters/json.rs
+++ b/src/exporters/json.rs
@@ -345,11 +345,13 @@ impl JsonExporter {
                     .get_processes_filtered_by_container_name(regex_filter)
             }
 
-            #[cfg(not(feature = "containers"))]
-            self.metric_generator
-                .topology
-                .proc_tracker
-                .get_top_consumers(max_top)
+            #[cfg(not(feature = "containers"))]{
+                info!("Container regex filter is used but containers feature is not present. Returning top consumers based on max-top-consumers.");
+                self.metric_generator
+                    .topology
+                    .proc_tracker
+                    .get_top_consumers(max_top)
+            }
         } else {
             self.metric_generator
                 .topology

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! `Exporter` is the root for all exporters. It defines the [Exporter] trait
 //! needed to implement an exporter.
+#[cfg(feature = "json")]
 pub mod json;
 #[cfg(feature = "prometheus")]
 pub mod prometheus;
@@ -18,7 +19,6 @@ use crate::sensors::{
     RecordGenerator, Topology,
 };
 use chrono::Utc;
-use clap::ArgMatches;
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
@@ -102,10 +102,11 @@ impl fmt::Debug for MetricValueType {
 /// the metrics are generated/refreshed by calling the refresh* methods available
 /// with the structs provided by the sensor.
 pub trait Exporter {
-    /// Entry point for all Exporters
-    fn run(&mut self, parameters: ArgMatches);
-    /// Get the options passed via the command line
-    fn get_options() -> Vec<clap::Arg>;
+    /// Runs the exporter.
+    fn run(&mut self);
+
+    /// The name of the kind of the exporter, for example "json".
+    fn kind(&self) -> &str;
 }
 
 /// MetricGenerator is an exporter helper structure to collect Scaphandre metrics.

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -39,15 +39,15 @@ pub struct ExporterArgs {
     pub address: IpAddr,
 
     /// TCP port of the metrics endpoint for Prometheus
-    #[arg(short, long)]
+    #[arg(short, long, default_value_t = 8080)]
     pub port: u16,
 
-    #[arg(short, long)]
+    #[arg(short, long, default_value_t = String::from("metrics"))]
     pub suffix: String,
 
     /// Apply labels to metrics of processes that look like a Qemu/KVM virtual machine
     #[arg(long)]
-    pub qmeu: bool,
+    pub qemu: bool,
 
     /// Apply labels to metrics of processes running as containers
     #[arg(long)]
@@ -82,7 +82,7 @@ impl Exporter for PrometheusExporter {
         let metric_generator = MetricGenerator::new(
             self.topo.clone(), // improvement possible here: avoid cloning by adding a lifetime param to MetricGenerator
             self.hostname.clone(),
-            self.args.qmeu,
+            self.args.qemu,
             self.args.containers,
         );
         run_server(socket_addr, metric_generator, &self.args.suffix);

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -1,136 +1,99 @@
 //! # PrometheusExporter
 //!
-//! `PrometheusExporter` implementation, expose metrics to
-//! a [Prometheus](https://prometheus.io/) server.
-use super::utils::get_hostname;
+//! The Prometheus Exporter expose metrics to a [Prometheus](https://prometheus.io/) server.
+//! This is achieved by exposing an HTTP endpoint, which the Prometheus will
+//! [scrape](https://prometheus.io/docs/prometheus/latest/getting_started).
+
+use super::utils;
 use crate::current_system_time_since_epoch;
 use crate::exporters::{Exporter, MetricGenerator, MetricValueType};
 use crate::sensors::{Sensor, Topology};
 use chrono::Utc;
-use clap::{Arg, ArgMatches};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
 use std::convert::Infallible;
-use std::fmt::Write as _;
 use std::{
     collections::HashMap,
-    net::{IpAddr, SocketAddr},
+    fmt::Write,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 /// Default ipv4/ipv6 address to expose the service is any
-const DEFAULT_IP_ADDRESS: &str = "::";
+const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
 
 /// Exporter that exposes metrics to an HTTP endpoint
 /// matching the Prometheus.io metrics format.
 pub struct PrometheusExporter {
-    /// Sensor instance that is used to generate the Topology and
-    /// thus get power consumption metrics.
-    sensor: Box<dyn Sensor>,
+    topo: Topology,
+    hostname: String,
+    args: ExporterArgs,
+}
+
+/// Hold the arguments for a PrometheusExporter.
+#[derive(clap::Args, Debug)]
+pub struct ExporterArgs {
+    /// IP address (v4 or v6) of the metrics endpoint for Prometheus
+    #[arg(short, long, default_value_t = DEFAULT_IP_ADDRESS)]
+    pub address: IpAddr,
+
+    /// TCP port of the metrics endpoint for Prometheus
+    #[arg(short, long)]
+    pub port: u16,
+
+    #[arg(short, long)]
+    pub suffix: String,
+
+    /// Apply labels to metrics of processes that look like a Qemu/KVM virtual machine
+    #[arg(long)]
+    pub qmeu: bool,
+
+    /// Apply labels to metrics of processes running as containers
+    #[arg(long)]
+    pub containers: bool,
 }
 
 impl PrometheusExporter {
     /// Instantiates PrometheusExporter and returns the instance.
-    pub fn new(sensor: Box<dyn Sensor>) -> PrometheusExporter {
-        PrometheusExporter { sensor }
+    pub fn new(sensor: &dyn Sensor, args: ExporterArgs) -> PrometheusExporter {
+        // Prepare the retrieval of the measurements, catch most of the errors early
+        let topo = sensor
+            .get_topology()
+            .expect("sensor topology should be available");
+        let hostname = utils::get_hostname();
+        PrometheusExporter {
+            topo,
+            hostname,
+            args,
+        }
     }
 }
 
 impl Exporter for PrometheusExporter {
-    /// Entry point ot the PrometheusExporter.
-    ///
-    /// Runs HTTP server and metrics exposure through the runner function.
-    fn run(&mut self, parameters: ArgMatches) {
+    /// Starts an HTTP server to expose the metrics in Prometheus format.
+    fn run(&mut self) {
         info!(
             "{}: Starting Prometheus exporter",
             Utc::now().format("%Y-%m-%dT%H:%M:%S")
         );
         println!("Press CTRL-C to stop scaphandre");
-
-        runner(
-            (*self.sensor.get_topology()).unwrap(),
-            parameters.get_one::<String>("address").unwrap().to_string(),
-            parameters.get_one::<String>("port").unwrap().to_string(),
-            parameters.get_one::<String>("suffix").unwrap().to_string(),
-            parameters.get_flag("qemu"),
-            parameters.get_flag("containers"),
-            get_hostname(),
+        let socket_addr = SocketAddr::new(self.args.address, self.args.port);
+        let metric_generator = MetricGenerator::new(
+            self.topo.clone(), // improvement possible here: avoid cloning by adding a lifetime param to MetricGenerator
+            self.hostname.clone(),
+            self.args.qmeu,
+            self.args.containers,
         );
+        run_server(socket_addr, metric_generator, &self.args.suffix);
     }
-    /// Returns options understood by the exporter.
-    fn get_options() -> Vec<clap::Arg> {
-        let mut options = Vec::new();
-        let arg = Arg::new("address")
-            .default_value(DEFAULT_IP_ADDRESS)
-            .help("ipv6 or ipv4 address to expose the service to")
-            .long("address")
-            .short('a')
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
 
-        let arg = Arg::new("port")
-            .default_value("8080")
-            .help("TCP port number to expose the service")
-            .long("port")
-            .short('p')
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("suffix")
-            .default_value("metrics")
-            .help("url suffix to access metrics")
-            .long("suffix")
-            .short('s')
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("qemu")
-            .help("Apply labels to metrics of processes looking like a Qemu/KVM virtual machine")
-            .long("qemu")
-            .short('q')
-            .required(false)
-            .action(clap::ArgAction::SetTrue);
-        options.push(arg);
-
-        let arg = Arg::new("containers")
-            .help("Monitor and apply labels for processes running as containers")
-            .long("containers")
-            .required(false)
-            .action(clap::ArgAction::SetTrue);
-        options.push(arg);
-
-        let arg = Arg::new("kubernetes_host")
-            .help("FQDN of the kubernetes API server")
-            .long("kubernetes-host")
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("kubernetes_scheme")
-            .help("Protocol used to access kubernetes API server")
-            .long("kubernetes-scheme")
-            .default_value("http")
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("kubernetes_port")
-            .help("Kubernetes API server port number")
-            .long("kubernetes-port")
-            .default_value("6443")
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        options
+    fn kind(&self) -> &str {
+        "prometheus"
     }
 }
 
-/// Contains a mutex holding a Topology object.
+/// Contains a mutex holding a MetricGenerator.
 /// Used to pass the topology data from one http worker to another.
 struct PowerMetrics {
     last_request: Mutex<Duration>,
@@ -138,55 +101,36 @@ struct PowerMetrics {
 }
 
 #[tokio::main]
-async fn runner(
-    topology: Topology,
-    address: String,
-    port: String,
-    suffix: String,
-    qemu: bool,
-    watch_containers: bool,
-    hostname: String,
+async fn run_server(
+    socket_addr: SocketAddr,
+    metric_generator: MetricGenerator,
+    endpoint_suffix: &str,
 ) {
-    if let Ok(addr) = address.parse::<IpAddr>() {
-        if let Ok(port) = port.parse::<u16>() {
-            let socket_addr = SocketAddr::new(addr, port);
-
-            let power_metrics = PowerMetrics {
-                last_request: Mutex::new(Duration::new(0, 0)),
-                metric_generator: Mutex::new(MetricGenerator::new(
-                    topology,
-                    hostname.clone(),
-                    qemu,
-                    watch_containers,
-                )),
-            };
-            let context = Arc::new(power_metrics);
-            let make_svc = make_service_fn(move |_| {
-                let ctx = context.clone();
-                let sfx = suffix.clone();
-                async {
-                    Ok::<_, Infallible>(service_fn(move |req| {
-                        show_metrics(req, ctx.clone(), sfx.clone())
-                    }))
-                }
-            });
-            let server = Server::bind(&socket_addr);
-            let res = server.serve(make_svc);
-            let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-            let graceful = res.with_graceful_shutdown(async {
-                rx.await.ok();
-            });
-
-            if let Err(e) = graceful.await {
-                error!("server error: {}", e);
-            }
-            let _ = tx.send(());
-        } else {
-            panic!("{} is not a valid TCP port number", port);
+    let power_metrics = PowerMetrics {
+        last_request: Mutex::new(Duration::new(0, 0)),
+        metric_generator: Mutex::new(metric_generator),
+    };
+    let context = Arc::new(power_metrics);
+    let make_svc = make_service_fn(move |_| {
+        let ctx = context.clone();
+        let sfx = endpoint_suffix.to_string();
+        async {
+            Ok::<_, Infallible>(service_fn(move |req| {
+                show_metrics(req, ctx.clone(), sfx.clone())
+            }))
         }
-    } else {
-        panic!("{} is not a valid ip address", address);
+    });
+    let server = Server::bind(&socket_addr);
+    let res = server.serve(make_svc);
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let graceful = res.with_graceful_shutdown(async {
+        rx.await.ok();
+    });
+
+    if let Err(e) = graceful.await {
+        error!("server error: {}", e);
     }
+    let _ = tx.send(());
 }
 
 /// Returns a well formatted Prometheus metric string.

--- a/src/exporters/riemann.rs
+++ b/src/exporters/riemann.rs
@@ -1,26 +1,22 @@
 //! # RiemannExporter
 //!
-//! `RiemannExporter` implementation, sends metrics to a [Riemann](https://riemann.io/)
-//! server.
+//! The Riemann exporter sends metrics to a [Riemann](https://riemann.io/) server.
+
 use crate::exporters::utils::get_hostname;
 use crate::exporters::*;
 use crate::sensors::Sensor;
 use chrono::Utc;
-use clap::value_parser;
-use clap::Arg;
-use riemann_client::proto::Attribute;
-use riemann_client::proto::Event;
+use riemann_client::proto::{Attribute, Event};
 use riemann_client::Client;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Riemann server default ipv4/ipv6 address
 const DEFAULT_IP_ADDRESS: &str = "localhost";
 
 /// Riemann server default port
-const DEFAULT_PORT: &str = "5555";
+const DEFAULT_PORT: u16 = 5555;
 
 /// RiemannClient is a simple client implementation on top of the
 /// [rust-riemann_client](https://github.com/borntyping/rust-riemann_client) library.
@@ -31,25 +27,6 @@ struct RiemannClient {
 }
 
 impl RiemannClient {
-    /// Instanciate the Riemann client either with mTLS or using raw TCP.
-    fn new(parameters: &ArgMatches) -> RiemannClient {
-        let address = parameters.get_one::<String>("address").unwrap().to_string();
-        let port: u16 = *parameters
-            .get_one("port")
-            .expect("Fail parsing port number");
-        let client: Client = if parameters.get_flag("mtls") {
-            let cafile = parameters.get_one::<String>("cafile").unwrap();
-            let certfile = parameters.get_one::<String>("certfile").unwrap();
-            let keyfile = parameters.get_one::<String>("keyfile").unwrap();
-            Client::connect_tls(&address, port, cafile, certfile, keyfile)
-                .expect("Fail to connect to Riemann server using mTLS")
-        } else {
-            Client::connect(&(address, port))
-                .expect("Fail to connect to Riemann server using raw TCP")
-        };
-        RiemannClient { client }
-    }
-
     /// Send metrics to the server.
     fn send_metric(&mut self, metric: &Metric) {
         let mut event = Event::new();
@@ -103,45 +80,103 @@ impl RiemannClient {
     }
 }
 
-/// Exporter sends metrics to a Riemann server.
+/// An exporter that sends metrics to a Riemann server.
 pub struct RiemannExporter {
-    /// Sensor instance that is used to generate the Topology and
-    /// thus get power consumption metrics.
-    sensor: Box<dyn Sensor>,
+    metric_generator: MetricGenerator,
+    riemann_client: RiemannClient,
+    args: ExporterArgs,
+}
+
+/// Contains the options of the Riemann exporter.
+#[derive(clap::Args, Debug)]
+pub struct ExporterArgs {
+    /// Address of the Riemann server. If mTLS is used this must be the server's FQDN.
+    #[arg(short, long, default_value = DEFAULT_IP_ADDRESS)]
+    pub address: String,
+
+    /// TCP port number of the Riemann server
+    #[arg(short, long, default_value_t = DEFAULT_PORT)]
+    pub port: u16,
+
+    /// Duration between each metric dispatch, in seconds
+    #[arg(short, long, default_value_t = 5)]
+    pub dispatch_interval: u64,
+
+    /// Apply labels to metrics of processes looking like a Qemu/KVM virtual machine
+    #[arg(short, long)]
+    pub qemu: bool,
+
+    /// Monitor and apply labels for processes running as containers
+    #[arg(long)]
+    pub containers: bool,
+
+    /// Connect to Riemann using mTLS instead of plain TCP.
+    #[arg(
+        long,
+        requires = "address",
+        requires = "ca_file",
+        requires = "cert_file",
+        requires = "key_file"
+    )]
+    pub mtls: bool,
+
+    /// CA certificate file (.pem format)
+    #[arg(long = "ca", requires = "mtls")]
+    pub ca_file: Option<String>,
+
+    /// Client certificate file (.pem format)
+    #[arg(long = "cert", requires = "mtls")]
+    pub cert_file: Option<String>,
+
+    /// Client RSA key file
+    #[arg(long = "key", requires = "mtls")]
+    pub key_file: Option<String>,
 }
 
 impl RiemannExporter {
     /// Returns a RiemannExporter instance.
-    pub fn new(sensor: Box<dyn Sensor>) -> RiemannExporter {
-        RiemannExporter { sensor }
+    pub fn new(sensor: &dyn Sensor, args: ExporterArgs) -> RiemannExporter {
+        // Prepare the retrieval of the measurements
+        let topo = sensor
+            .get_topology()
+            .expect("sensor topology should be available");
+        let metric_generator =
+            MetricGenerator::new(topo, utils::get_hostname(), args.qemu, args.containers);
+
+        // Initialize the connection to the Riemann server
+        let client = if args.mtls {
+            Client::connect_tls(
+                &args.address,
+                args.port,
+                &args.ca_file.clone().unwrap(),
+                &args.cert_file.clone().unwrap(),
+                &args.key_file.clone().unwrap(),
+            )
+            .expect("failed to connect to Riemann using mTLS")
+        } else {
+            Client::connect(&(args.address.clone(), args.port))
+                .expect("failed to connect to Riemann using raw TCP")
+        };
+        let riemann_client = RiemannClient { client };
+        RiemannExporter {
+            metric_generator,
+            riemann_client,
+            args,
+        }
     }
 }
 
 impl Exporter for RiemannExporter {
     /// Entry point of the RiemannExporter.
-    fn run(&mut self, parameters: ArgMatches) {
-        let dispatch_duration: u64 = *parameters
-            .get_one("dispatch_duration")
-            .expect("Wrong dispatch_duration value, should be a number of seconds");
-
-        let hostname = get_hostname();
-
-        let mut rclient = RiemannClient::new(&parameters);
-
+    fn run(&mut self) {
         info!(
             "{}: Starting Riemann exporter",
             Utc::now().format("%Y-%m-%dT%H:%M:%S")
         );
         println!("Press CTRL-C to stop scaphandre");
-        println!("Measurement step is: {dispatch_duration}s");
 
-        let topology = self.sensor.get_topology().unwrap();
-        let mut metric_generator = MetricGenerator::new(
-            topology,
-            hostname,
-            parameters.get_flag("qemu"),
-            parameters.get_flag("containers"),
-        );
+        let dispatch_interval = Duration::from_secs(self.args.dispatch_interval);
+        println!("Dispatch interval is {dispatch_interval:?}");
 
         loop {
             info!(
@@ -149,7 +184,7 @@ impl Exporter for RiemannExporter {
                 Utc::now().format("%Y-%m-%dT%H:%M:%S")
             );
 
-            metric_generator
+            self.metric_generator
                 .topology
                 .proc_tracker
                 .clean_terminated_process_records_vectors();
@@ -158,17 +193,17 @@ impl Exporter for RiemannExporter {
                 "{}: Refresh topology",
                 Utc::now().format("%Y-%m-%dT%H:%M:%S")
             );
-            metric_generator.topology.refresh();
+            self.metric_generator.topology.refresh();
 
             info!("{}: Refresh data", Utc::now().format("%Y-%m-%dT%H:%M:%S"));
             // Here we need a specific behavior for process metrics, so we call each gen function
             // and then implement that specific behavior (we don't use gen_all_metrics).
-            metric_generator.gen_self_metrics();
-            metric_generator.gen_host_metrics();
-            metric_generator.gen_socket_metrics();
+            self.metric_generator.gen_self_metrics();
+            self.metric_generator.gen_host_metrics();
+            self.metric_generator.gen_socket_metrics();
 
             let mut data = vec![];
-            let processes_tracker = &metric_generator.topology.proc_tracker;
+            let processes_tracker = &self.metric_generator.topology.proc_tracker;
 
             for pid in processes_tracker.get_alive_pids() {
                 let exe = processes_tracker.get_process_name(pid);
@@ -182,7 +217,7 @@ impl Exporter for RiemannExporter {
                 if let Some(cmdline_str) = cmdline {
                     attributes.insert("cmdline".to_string(), cmdline_str.replace('\"', "\\\""));
 
-                    if parameters.get_flag("qemu") {
+                    if self.args.qemu {
                         if let Some(vmname) = utils::filter_qemu_cmdline(&cmdline_str) {
                             attributes.insert("vmname".to_string(), vmname);
                         }
@@ -195,7 +230,8 @@ impl Exporter for RiemannExporter {
                     "{}_{}_{}",
                     "scaph_process_power_consumption_microwatts", pid, exe
                 );
-                if let Some(power) = metric_generator
+                if let Some(power) = self
+                    .metric_generator
                     .topology
                     .get_process_power_consumption_microwatts(pid)
                 {
@@ -215,100 +251,20 @@ impl Exporter for RiemannExporter {
             }
             // Send all data
             info!("{}: Send data", Utc::now().format("%Y-%m-%dT%H:%M:%S"));
-            for metric in metric_generator.pop_metrics() {
-                rclient.send_metric(&metric);
+            for metric in self.metric_generator.pop_metrics() {
+                self.riemann_client.send_metric(&metric);
             }
             for metric in data {
-                rclient.send_metric(&metric);
+                self.riemann_client.send_metric(&metric);
             }
 
-            thread::sleep(Duration::new(dispatch_duration, 0));
+            // Pause for some time
+            std::thread::sleep(dispatch_interval);
         }
     }
 
-    /// Returns options understood by the exporter.
-    fn get_options() -> Vec<clap::Arg> {
-        let mut options = Vec::new();
-        let arg = Arg::new("address")
-            .default_value(DEFAULT_IP_ADDRESS)
-            .help("Riemann ipv6 or ipv4 address. If mTLS is used then server fqdn must be provided")
-            .long("address")
-            .short('a')
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("port")
-            .default_value(DEFAULT_PORT)
-            .help("Riemann TCP port number")
-            .long("port")
-            .short('p')
-            .required(false)
-            .value_parser(value_parser!(u16))
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("dispatch_duration")
-            .default_value("5")
-            .help("Duration between metrics dispatch")
-            .long("dispatch")
-            .short('d')
-            .required(false)
-            .value_parser(value_parser!(u64))
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("qemu")
-            .help("Instruct that scaphandre is running on an hypervisor")
-            .long("qemu")
-            .short('q')
-            .required(false)
-            .action(clap::ArgAction::SetTrue);
-        options.push(arg);
-
-        let arg = Arg::new("containers")
-            .help("Monitor and apply labels for processes running as containers")
-            .long("containers")
-            .required(false)
-            .action(clap::ArgAction::SetTrue);
-        options.push(arg);
-
-        let arg = Arg::new("mtls")
-            .help("Connect to a Riemann server using mTLS. Parameters address, ca, cert and key must be defined.")
-            .long("mtls")
-            .required(false)
-            .requires_all(["address","cafile", "certfile", "keyfile"])
-            .action(clap::ArgAction::SetTrue);
-        options.push(arg);
-
-        let arg = Arg::new("cafile")
-            .help("CA certificate file (.pem format)")
-            .long("ca")
-            .required(false)
-            .action(clap::ArgAction::Set)
-            .display_order(1000)
-            .requires("mtls");
-        options.push(arg);
-
-        let arg = Arg::new("certfile")
-            .help("Client certificate file (.pem format)")
-            .long("cert")
-            .required(false)
-            .action(clap::ArgAction::Set)
-            .display_order(1001)
-            .requires("mtls");
-        options.push(arg);
-
-        let arg = Arg::new("keyfile")
-            .help("Client RSA key")
-            .long("key")
-            .required(false)
-            .action(clap::ArgAction::Set)
-            .display_order(1001)
-            .requires("mtls");
-        options.push(arg);
-
-        options
+    fn kind(&self) -> &str {
+        "riemann"
     }
 }
 

--- a/src/exporters/warpten.rs
+++ b/src/exporters/warpten.rs
@@ -106,37 +106,27 @@ impl Warp10Exporter {
 
         self.metric_generator.gen_all_metrics();
 
-        let process_data: Vec<warp10::Data> = vec![];
+        let mut process_data: Vec<warp10::Data> = vec![];
 
         for metric in self.metric_generator.pop_metrics() {
             let mut labels = vec![];
 
-            for (k, v) in metric.attributes {
+            for (k, v) in &metric.attributes {
                 labels.push(warp10::Label::new(&k, &v));
             }
 
-            //if !metric.name.starts_with("scaph_domain") && !metric.name.starts_with("scaph_socket") {
-            //    process_data.push(warp10::Data::new(
-            //        time::OffsetDateTime::now_utc(),
-            //        None,
-            //        metric.name,
-            //        labels,
-            //        warp10::Value::String(metric.metric_value.to_string()),
-            //    ));
-            //}
+            process_data.push(warp10::Data::new(
+                time::OffsetDateTime::now_utc(),
+                None,
+                metric.name,
+                labels,
+                warp10::Value::String(metric.metric_value.to_string().replace("`", "")),
+            ));
         }
 
         let res = writer.post_sync(process_data)?;
 
         let results = vec![res];
-
-        //let mut process_data = vec![warp10::Data::new(
-        //    time::OffsetDateTime::now_utc(),
-        //    None,
-        //    String::from("scaph_self_version"),
-        //    labels.clone(),
-        //    warp10::Value::Double(scaphandre_version.parse::<f64>().unwrap()),
-        //)];
 
         //if let Some(token) = read_token {
         //let reader = client.get_reader(token.to_owned());

--- a/src/exporters/warpten.rs
+++ b/src/exporters/warpten.rs
@@ -112,7 +112,7 @@ impl Warp10Exporter {
             let mut labels = vec![];
 
             for (k, v) in &metric.attributes {
-                labels.push(warp10::Label::new(&k, &v));
+                labels.push(warp10::Label::new(k, v));
             }
 
             process_data.push(warp10::Data::new(
@@ -120,7 +120,7 @@ impl Warp10Exporter {
                 None,
                 metric.name,
                 labels,
-                warp10::Value::String(metric.metric_value.to_string().replace("`", "")),
+                warp10::Value::String(metric.metric_value.to_string().replace('`', "")),
             ));
         }
 

--- a/src/exporters/warpten.rs
+++ b/src/exporters/warpten.rs
@@ -1,145 +1,101 @@
 use super::utils::get_hostname;
 use crate::exporters::*;
 use crate::sensors::Sensor;
-use clap::{value_parser, Arg};
 use std::time::Duration;
-use std::{env, thread};
-
-//use warp10::data::Format;
 
 /// An exporter that sends power consumption data of the host and its processes to
 /// a [Warp10](https://warp10.io) instance through **HTTP(s)**
 /// (contributions welcome to support websockets).
 pub struct Warp10Exporter {
     metric_generator: MetricGenerator,
+    /// Warp10 client
+    client: warp10::Client,
+    /// Warp10 auth token
+    write_token: String,
+
+    step: Duration,
 }
 
-impl Exporter for Warp10Exporter {
-    /// Control loop for self.iteration()
-    fn run(&mut self, parameters: clap::ArgMatches) {
-        let host = parameters.get_one::<String>("host").unwrap();
-        let scheme = parameters.get_one::<String>("scheme").unwrap();
-        let port = parameters.get_one::<String>("port").unwrap();
-        let write_token = if let Some(token) = parameters.get_one::<String>("write-token") {
-            token.to_owned()
-        } else {
-            match env::var("SCAPH_WARP10_WRITE_TOKEN") {
-                Ok(val) => val,
-                Err(_e) => panic!(
-                    "SCAPH_WARP10_WRITE_TOKEN not found in env, nor write-token flag was used."
-                ),
-            }
-        };
-        //let read_token = parameters.value_of("read-token");
-        let step: u64 = *parameters.get_one("step").unwrap();
-        let qemu = parameters.get_flag("qemu");
-        let watch_containers = parameters.get_flag("containers");
-        self.metric_generator.watch_containers = watch_containers;
-        self.metric_generator.qemu = qemu;
+/// Holds the arguments for a Warp10Exporter.
+#[derive(clap::Args, Debug)]
+pub struct ExporterArgs {
+    /// FQDN or IP address of the Warp10 instance
+    #[arg(short = 'H', long, default_value = "localhost")]
+    pub host: String,
 
+    /// TCP port of the Warp10 instance
+    #[arg(short, long, default_value_t = 8080)]
+    pub port: u16,
+
+    /// "http" or "https"
+    #[arg(short = 'S', long, default_value = "http")]
+    pub scheme: String,
+
+    /// Auth token to write data to Warp10.
+    /// If not specified, you must set the env variable SCAPH_WARP10_WRITE_TOKEN
+    #[arg(short = 't', long)]
+    pub write_token: Option<String>,
+
+    /// Interval between two measurements, in seconds
+    #[arg(short, long, value_name = "SECONDS", default_value_t = 2)]
+    pub step: u64,
+
+    /// Apply labels to metrics of processes looking like a Qemu/KVM virtual machine
+    #[arg(short, long)]
+    pub qemu: bool,
+}
+
+const TOKEN_ENV_VAR: &str = "SCAPH_WARP10_WRITE_TOKEN";
+
+impl Exporter for Warp10Exporter {
+    /// Control loop for self.iterate()
+    fn run(&mut self) {
         loop {
-            match self.iteration(host, scheme, port.parse::<u16>().unwrap(), &write_token) {
+            match self.iterate() {
                 Ok(res) => debug!("Result: {:?}", res),
                 Err(err) => error!("Failed ! {:?}", err),
             }
-            thread::sleep(Duration::new(step, 0));
+            std::thread::sleep(self.step);
         }
     }
 
-    /// Options for configuring the exporter.
-    fn get_options() -> Vec<clap::Arg> {
-        let mut options = Vec::new();
-        let arg = Arg::new("host")
-            .default_value("localhost")
-            .help("Warp10 host's FQDN or IP address to send data to")
-            .long("host")
-            .short('H')
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("scheme")
-            .default_value("http")
-            .help("Either 'http' or 'https'")
-            .long("scheme")
-            .short('s')
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("port")
-            .default_value("8080")
-            .help("TCP port to join Warp10 on the host")
-            .long("port")
-            .short('p')
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("write-token")
-            .help("Auth. token to write on Warp10")
-            .long("write-token")
-            .short('t')
-            .required(false)
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("step")
-            .default_value("30")
-            .help("Time step between measurements, in seconds.")
-            .long("step")
-            .short('S')
-            .required(false)
-            .value_parser(value_parser!(u64))
-            .action(clap::ArgAction::Set);
-        options.push(arg);
-
-        let arg = Arg::new("qemu")
-            .help("Tells scaphandre it is running on a Qemu hypervisor.")
-            .long("qemu")
-            .short('q')
-            .required(false)
-            .action(clap::ArgAction::SetTrue);
-        options.push(arg);
-
-        let arg = Arg::new("containers")
-            .help("Monitor and apply labels for processes running as containers")
-            .long("containers")
-            .required(false)
-            .action(clap::ArgAction::SetTrue);
-        options.push(arg);
-
-        options
+    fn kind(&self) -> &str {
+        "warp10"
     }
 }
 
 impl Warp10Exporter {
     /// Instantiates and returns a new Warp10Exporter
-    pub fn new(mut sensor: Box<dyn Sensor>) -> Warp10Exporter {
-        let topology = match *sensor.get_topology() {
-            Some(topo) => topo,
-            None => {
-                panic!("Couldn't generate the Topology");
-            }
-        };
-        let metric_generator = MetricGenerator::new(topology, get_hostname(), false, false);
-        Warp10Exporter { metric_generator }
+    pub fn new(sensor: &dyn Sensor, args: ExporterArgs) -> Warp10Exporter {
+        // Prepare for measurement
+        let topology = sensor
+            .get_topology()
+            .expect("sensor topology should be available");
+        let metric_generator = MetricGenerator::new(topology, get_hostname(), args.qemu, false);
+
+        // Prepare for sending data to Warp10
+        let scheme = args.scheme;
+        let host = args.host;
+        let port = args.port;
+        let client = warp10::Client::new(&format!("{scheme}://{host}:{port}"))
+            .expect("warp10 Client could not be created");
+        let write_token = args.write_token.unwrap_or_else(|| {
+            std::env::var(TOKEN_ENV_VAR).unwrap_or_else(|_| panic!("No token found, you must provide either --write-token or the env var {TOKEN_ENV_VAR}"))
+        });
+
+        Warp10Exporter {
+            metric_generator,
+            client,
+            write_token,
+            step: Duration::from_secs(args.step),
+        }
     }
 
     /// Collects data from the Topology, creates warp10::Data objects containing the
     /// metric itself and some labels attaches, stores them in a vector and sends it
     /// to Warp10
-    pub fn iteration(
-        &mut self,
-        host: &str,
-        scheme: &str,
-        port: u16,
-        write_token: &str,
-        //read_token: Option<&str>,
-    ) -> Result<Vec<warp10::Warp10Response>, warp10::Error> {
-        let client = warp10::Client::new(&format!("{scheme}://{host}:{port}"))?;
-        let writer = client.get_writer(write_token.to_string());
-
+    pub fn iterate(&mut self) -> Result<Vec<warp10::Warp10Response>, warp10::Error> {
+        let writer = self.client.get_writer(self.write_token.clone());
         self.metric_generator
             .topology
             .proc_tracker

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,164 +7,33 @@
 extern crate log;
 pub mod exporters;
 pub mod sensors;
-use clap::ArgMatches;
-use colored::*;
-#[cfg(feature = "json")]
-use exporters::json::JSONExporter;
-#[cfg(feature = "prometheus")]
-use exporters::prometheus::PrometheusExporter;
-#[cfg(target_os = "linux")]
-use exporters::qemu::QemuExporter;
-#[cfg(feature = "riemann")]
-use exporters::riemann::RiemannExporter;
-#[cfg(feature = "warpten")]
-use exporters::warpten::Warp10Exporter;
-use exporters::{stdout::StdoutExporter, Exporter};
+
 #[cfg(target_os = "windows")]
-use sensors::msr_rapl::MsrRAPLSensor;
+use sensors::msr_rapl;
+
 #[cfg(target_os = "linux")]
-use sensors::powercap_rapl::PowercapRAPLSensor;
-use sensors::Sensor;
-use std::collections::HashMap;
+use sensors::powercap_rapl;
+
 use std::time::{Duration, SystemTime};
 
-/// Helper function to get a Sensor instance from ArgMatches
-fn get_sensor(matches: &ArgMatches) -> Box<dyn Sensor> {
-    let sensor = match matches.get_one::<String>("sensor").unwrap().as_str() {
-        #[cfg(target_os = "linux")]
-        "powercap_rapl" => PowercapRAPLSensor::new(
-            *matches.get_one("sensor-buffer-per-socket-max-kB").unwrap(),
-            *matches.get_one("sensor-buffer-per-domain-max-kB").unwrap(),
-            matches.get_flag("vm"),
-        ),
-        #[cfg(target_os = "linux")]
-        _ => PowercapRAPLSensor::new(
-            *matches.get_one("sensor-buffer-per-socket-max-kB").unwrap(),
-            *matches.get_one("sensor-buffer-per-domain-max-kB").unwrap(),
-            matches.get_flag("vm"),
-        ),
-        #[cfg(not(target_os = "linux"))]
-        _ => MsrRAPLSensor::new(),
-    };
-    Box::new(sensor)
-}
-
-/// Matches the sensor and exporter name and options requested from the command line and
-/// creates the appropriate instances. Launchs the standardized entrypoint of
-/// the choosen exporter: run()
-/// This function should be updated to take new exporters into account.
-pub fn run(matches: ArgMatches) {
-    loggerv::init_with_verbosity(u64::from(matches.get_count("v"))).unwrap();
-
-    let sensor_boxed = get_sensor(&matches);
-    let exporter_parameters;
-
-    let mut header = true;
-    if matches.get_flag("no-header") {
-        header = false;
-    }
-
-    if let Some(stdout_exporter_parameters) = matches.subcommand_matches("stdout") {
-        if header {
-            scaphandre_header("stdout");
-        }
-        exporter_parameters = stdout_exporter_parameters.clone();
-        let mut exporter = StdoutExporter::new(sensor_boxed);
-        exporter.run(exporter_parameters);
-    } else if let Some(json_exporter_parameters) = matches.subcommand_matches("json") {
-        if header {
-            scaphandre_header("json");
-        }
-        exporter_parameters = json_exporter_parameters.clone();
-        let mut exporter = JSONExporter::new(sensor_boxed);
-        exporter.run(exporter_parameters);
-    } else if let Some(riemann_exporter_parameters) = matches.subcommand_matches("riemann") {
-        if header {
-            scaphandre_header("riemann");
-        }
-        exporter_parameters = riemann_exporter_parameters.clone();
-        let mut exporter = RiemannExporter::new(sensor_boxed);
-        exporter.run(exporter_parameters);
-    } else if let Some(prometheus_exporter_parameters) = matches.subcommand_matches("prometheus") {
-        if header {
-            scaphandre_header("prometheus");
-        }
-        exporter_parameters = prometheus_exporter_parameters.clone();
-        let mut exporter = PrometheusExporter::new(sensor_boxed);
-        exporter.run(exporter_parameters);
-    } else if let Some(warp10_exporter_parameters) = matches.subcommand_matches("warp10") {
-        #[cfg(feature = "warpten")]
-        {
-            if header {
-                scaphandre_header("warp10");
-            }
-            exporter_parameters = warp10_exporter_parameters.clone();
-            let mut exporter = Warp10Exporter::new(sensor_boxed);
-            exporter.run(exporter_parameters);
-        }
-    } else {
-        #[cfg(target_os = "linux")]
-        {
-            if let Some(qemu_exporter_parameters) = matches.subcommand_matches("qemu") {
-                if header {
-                    scaphandre_header("qemu");
-                }
-                exporter_parameters = qemu_exporter_parameters.clone();
-                let mut exporter = QemuExporter::new(sensor_boxed);
-                exporter.run(exporter_parameters);
-            }
-            error!("Warp10 exporter feature was not included in this build.");
-        }
-        error!("Couldn't determine which exporter to run.");
-    }
-}
-
-/// Returns options needed for each exporter as a HashMap.
-/// This function has to be updated to enable a new exporter.
-pub fn get_exporters_options() -> HashMap<String, Vec<clap::Arg>> {
-    let mut options = HashMap::new();
-    options.insert(
-        String::from("stdout"),
-        exporters::stdout::StdoutExporter::get_options(),
-    );
-    #[cfg(feature = "json")]
-    options.insert(
-        String::from("json"),
-        exporters::json::JSONExporter::get_options(),
-    );
-    #[cfg(feature = "prometheus")]
-    options.insert(
-        String::from("prometheus"),
-        exporters::prometheus::PrometheusExporter::get_options(),
-    );
-    #[cfg(feature = "riemann")]
-    options.insert(
-        String::from("riemann"),
-        exporters::riemann::RiemannExporter::get_options(),
-    );
+/// Create a new [`Sensor`] instance with the default sensor available,
+/// with its default options.
+pub fn get_default_sensor() -> impl sensors::Sensor {
     #[cfg(target_os = "linux")]
-    options.insert(
-        String::from("qemu"),
-        exporters::qemu::QemuExporter::get_options(),
+    return powercap_rapl::PowercapRAPLSensor::new(
+        powercap_rapl::DEFAULT_BUFFER_PER_SOCKET_MAX_KBYTES,
+        powercap_rapl::DEFAULT_BUFFER_PER_DOMAIN_MAX_KBYTES,
+        false,
     );
-    #[cfg(feature = "warp10")]
-    options.insert(
-        String::from("warp10"),
-        exporters::warpten::Warp10Exporter::get_options(),
-    );
-    options
+
+    #[cfg(target_os = "windows")]
+    return msr_rapl::MsrRAPLSensor::new();
 }
 
 fn current_system_time_since_epoch() -> Duration {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
-}
-
-pub fn scaphandre_header(exporter_name: &str) {
-    let title = format!("Scaphandre {exporter_name} exporter");
-    println!("{}", title.red().bold());
-    println!("Sending ⚡ metrics");
 }
 
 /// Returns rust crate version, can be use used in language bindings to expose Rust core version

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,93 +1,195 @@
 //! Generic sensor and transmission agent for energy consumption related metrics.
 
-use clap::{crate_authors, crate_version, value_parser, Arg, ArgAction, Command};
-use scaphandre::{get_exporters_options, run};
+use clap::{command, ArgAction, Parser, Subcommand};
+use colored::Colorize;
+use scaphandre::{exporters, sensors::Sensor};
+
+#[cfg(target_os = "linux")]
+use scaphandre::sensors::powercap_rapl;
+
+// the struct below defines the main Scaphandre command-line interface
+/// Extensible metrology agent for electricity consumption related metrics.
+#[derive(Parser)]
+#[command(author, version)]
+struct Cli {
+    /// The exporter module to use to output the energy consumption metrics
+    #[command(subcommand)]
+    exporter: ExporterChoice,
+
+    /// Increase the verbosity level
+    #[arg(short, action = ArgAction::Count, default_value_t = 0)]
+    verbose: u8,
+
+    /// Don't print the header to the standard output
+    #[arg(long, default_value_t = false)]
+    no_header: bool,
+
+    /// Tell Scaphandre that it's running in a virtual machine.
+    /// You should have another instance of Scaphandre running on the hypervisor (see docs).
+    #[arg(long, default_value_t = false)]
+    vm: bool,
+
+    /// The sensor module to use to gather the energy consumption metrics
+    #[arg(short, long)]
+    sensor: Option<String>,
+
+    /// Maximum memory size allowed, in KiloBytes, for storing energy consumption of each **domain**.
+    /// Only available for the RAPL sensor (on Linux).
+    #[cfg(target_os = "linux")]
+    #[arg(long, default_value_t = powercap_rapl::DEFAULT_BUFFER_PER_DOMAIN_MAX_KBYTES)]
+    sensor_buffer_per_domain_max_kb: u16,
+
+    /// Maximum memory size allowed, in KiloBytes, for storing energy consumption of each **socket**.
+    /// Only available for the RAPL sensor (on Linux).
+    #[cfg(target_os = "linux")]
+    #[arg(long, default_value_t = powercap_rapl::DEFAULT_BUFFER_PER_SOCKET_MAX_KBYTES)]
+    sensor_buffer_per_socket_max_kb: u16,
+}
+
+/// Defines the possible subcommands, one per exporter.
+/// 
+/// ### Description style
+/// Per the clap documentation, the description of commands and arguments should be written in the style applied here,
+/// *not* in the third-person. That is, use "Do xyz" instead of "Does xyz".
+#[derive(Subcommand)]
+enum ExporterChoice {
+    /// Write the metrics in the JSON format to a file or to stdout
+    #[cfg(feature = "json")]
+    Json(exporters::json::ExporterArgs),
+
+    /// Expose the metrics to a Prometheus HTTP endpoint
+    #[cfg(feature = "prometheus")]
+    Prometheus(exporters::prometheus::ExporterArgs),
+
+    /// Watch all Qemu-KVM virtual machines running on the host and expose the metrics
+    /// of each of them in a dedicated folder
+    #[cfg(feature = "qemu")]
+    Qemu,
+
+    /// Expose the metrics to a Riemann server
+    #[cfg(feature = "riemann")]
+    Riemann(exporters::riemann::ExporterArgs),
+
+    /// Write the metrics to the terminal
+    Stdout(exporters::stdout::ExporterArgs),
+
+    /// Expose the metrics to a Warp10 host, through HTTP
+    #[cfg(feature = "warpten")]
+    Warpten(exporters::warpten::ExporterArgs),
+}
+
 fn main() {
-    #[cfg(target_os = "linux")]
-    let sensors = ["powercap_rapl"];
-    #[cfg(target_os = "windows")]
-    let sensors = ["msr_rapl"];
-    let exporters_options = get_exporters_options();
-    let exporters: Vec<String> = exporters_options.keys().map(|x| x.to_string()).collect();
+    let cli = Cli::parse();
+    loggerv::init_with_verbosity(cli.verbose.into()).expect("unable to initialize the logger");
 
-    #[cfg(target_os = "linux")]
-    let sensor_default_value = String::from("powercap_rapl");
-    #[cfg(not(target_os = "linux"))]
-    let sensor_default_value = String::from("msr_rapl");
-
-    let mut matches = Command::new("scaphandre")
-        .author(crate_authors!())
-        .version(crate_version!())
-        .about("Extensible metrology agent for energy/electricity consumption related metrics")
-        .arg(
-            Arg::new("v")
-                .short('v')
-                .help("Sets the level of verbosity.")
-                .action(ArgAction::Count)
-        )
-        .arg(
-            Arg::new("no-header")
-                .value_name("no-header")
-                .help("Prevents the header to be displayed in the terminal output.")
-                .required(false)
-                .long("no-header")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("sensor")
-                .value_name("sensor")
-                .help("Sensor module to apply on the host to get energy consumption metrics.")
-                .required(false)
-                .default_value(&sensor_default_value)
-                .short('s')
-                .long("sensor")
-                .value_parser(sensors)
-                .action(clap::ArgAction::Set)
-        ).arg(
-            Arg::new("sensor-buffer-per-domain-max-kB")
-                .value_name("sensor-buffer-per-domain-max-kB")
-                .help("Maximum memory size allowed, in KiloBytes, for storing energy consumption of each domain.")
-                .required(false)
-                .default_value("1")
-                .value_parser(value_parser!(u16))
-                .action(clap::ArgAction::Set)
-        ).arg(
-            Arg::new("sensor-buffer-per-socket-max-kB")
-                .value_name("sensor-buffer-per-socket-max-kB")
-                .help("Maximum memory size allowed, in KiloBytes, for storing energy consumption of each socket.")
-                .required(false)
-                .default_value("1")
-                .value_parser(value_parser!(u16))
-                .action(clap::ArgAction::Set)
-        ).arg(
-            Arg::new("vm")
-                .value_name("vm")
-                .help("Tell scaphandre if he is running in a virtual machine.")
-                .long("vm")
-                .required(false)
-                .action(clap::ArgAction::SetTrue),
-        );
-
-    for exporter in exporters {
-        let mut subcmd = Command::new(&exporter).about(
-            match exporter.as_str() {
-                "stdout" => "Stdout exporter allows you to output the power consumption data in the terminal",
-                "json" => "JSON exporter allows you to output the power consumption data in a json file",
-                "prometheus" => "Prometheus exporter exposes power consumption metrics on an http endpoint (/metrics is default) in prometheus accepted format",
-                "riemann" => "Riemann exporter sends power consumption metrics to a Riemann server",
-                "qemu" => "Qemu exporter watches all Qemu/KVM virtual machines running on the host and exposes metrics of each of them in a dedicated folder",
-                "warp10" => "Warp10 exporter sends data to a Warp10 host, through HTTP",
-                _ => "Unknown exporter",
-            }
-        );
-
-        let myopts = exporters_options.get(&exporter).unwrap();
-        for opt in myopts {
-            subcmd = subcmd.arg(opt);
-        }
-        matches = matches.subcommand(subcmd);
+    let sensor = build_sensor(&cli);
+    let mut exporter = build_exporter(cli.exporter, &sensor);
+    if !cli.no_header {
+        print_scaphandre_header(exporter.kind());
     }
-    run(matches.get_matches());
+
+    exporter.run();
+}
+
+fn build_exporter(choice: ExporterChoice, sensor: &dyn Sensor) -> Box<dyn exporters::Exporter> {
+    match choice {
+        ExporterChoice::Json(args) => {
+            Box::new(exporters::json::JsonExporter::new(sensor, args)) // keep this in braces
+        }
+        ExporterChoice::Prometheus(args) => {
+            Box::new(exporters::prometheus::PrometheusExporter::new(sensor, args))
+        }
+        ExporterChoice::Qemu => {
+            Box::new(exporters::qemu::QemuExporter::new(sensor)) // keep this in braces
+        }
+        ExporterChoice::Riemann(args) => {
+            Box::new(exporters::riemann::RiemannExporter::new(sensor, args))
+        }
+        ExporterChoice::Stdout(args) => {
+            Box::new(exporters::stdout::StdoutExporter::new(sensor, args))
+        }
+        ExporterChoice::Warpten(args) => {
+            Box::new(exporters::warpten::Warp10Exporter::new(sensor, args))
+        }
+    }
+    // Note that invalid choices are automatically turned into errors by `parse()` before the Cli is populated,
+    // that's why they don't appear in this function.
+}
+
+/// Returns the sensor to use, given the command-line arguments.
+/// Unless sensor-specific options are provided, this should return
+/// the same thing as [`scaphandre::get_default_sensor`].
+fn build_sensor(cli: &Cli) -> impl Sensor {
+    #[cfg(target_os = "linux")]
+    let rapl_sensor = || {
+        powercap_rapl::PowercapRAPLSensor::new(
+            cli.sensor_buffer_per_socket_max_kb,
+            cli.sensor_buffer_per_domain_max_kb,
+            cli.vm,
+        )
+    };
+
+    #[cfg(target_os = "windows")]
+    let msr_sensor_win = || sensors::msr_rapl::MsrRAPLSensor::new();
+
+    match cli.sensor.as_deref() {
+        Some("powercap_rapl") => {
+            #[cfg(target_os = "linux")]
+            {
+                rapl_sensor()
+            }
+            #[cfg(not(target_os = "linux"))]
+            panic!("Invalid sensor: Scaphandre's powercap_rapl only works on Linux")
+        }
+        Some("msr") => {
+            #[cfg(target_os = "windows")]
+            {
+                msr_sensor()
+            }
+            #[cfg(not(target_os = "windows"))]
+            panic!("Invalid sensor: Scaphandre's msr only works on Windows")
+        }
+        Some(s) => panic!("Unknown sensor type {}", s),
+        None => {
+            #[cfg(target_os = "linux")]
+            return rapl_sensor();
+
+            #[cfg(target_os = "windows")]
+            return msr_sensor_win();
+
+            #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+            compile_error!("Unsupported target OS")
+        }
+    }
+}
+
+fn print_scaphandre_header(exporter_name: &str) {
+    let title = format!("Scaphandre {exporter_name} exporter");
+    println!("{}", title.red().bold());
+    println!("Sending ⚡ metrics");
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    const SUBCOMMANDS: [&str; 6] = ["json", "prometheus", "qemu", "riemann", "stdout", "warpten"];
+    
+    /// Test that `--help` works for Scaphandre _and_ for each subcommand.
+    /// This also ensures that all the subcommands are properly defined, as Clap will check some constraints
+    /// when trying to parse a subcommand (for instance, it will check that no two short options have the same name).
+    #[test]
+    fn test_help() {
+        fn assert_shows_help(args: &[&str]) {
+            match Cli::try_parse_from(args) {
+                Ok(_) => panic!("The CLI didn't generate a help message for {:?}, are the inputs correct?", args),
+                Err(e) => assert_eq!(e.kind(), clap::error::ErrorKind::DisplayHelp, "The CLI emitted an error for {args:?}:\n{e}")
+            };
+        }
+        assert_shows_help(&["scaphandre", "--help"]);
+        for cmd in SUBCOMMANDS {
+            assert_shows_help(&["scaphandre", cmd, "--help"]);
+        }
+    }
 }
 
 //  Copyright 2020 The scaphandre authors.

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ struct Cli {
 }
 
 /// Defines the possible subcommands, one per exporter.
-/// 
+///
 /// ### Description style
 /// Per the clap documentation, the description of commands and arguments should be written in the style applied here,
 /// *not* in the third-person. That is, use "Do xyz" instead of "Does xyz".
@@ -173,7 +173,7 @@ fn print_scaphandre_header(exporter_name: &str) {
 mod test {
     use super::*;
     const SUBCOMMANDS: [&str; 6] = ["json", "prometheus", "qemu", "riemann", "stdout", "warpten"];
-    
+
     /// Test that `--help` works for Scaphandre _and_ for each subcommand.
     /// This also ensures that all the subcommands are properly defined, as Clap will check some constraints
     /// when trying to parse a subcommand (for instance, it will check that no two short options have the same name).
@@ -181,8 +181,14 @@ mod test {
     fn test_help() {
         fn assert_shows_help(args: &[&str]) {
             match Cli::try_parse_from(args) {
-                Ok(_) => panic!("The CLI didn't generate a help message for {:?}, are the inputs correct?", args),
-                Err(e) => assert_eq!(e.kind(), clap::error::ErrorKind::DisplayHelp, "The CLI emitted an error for {args:?}:\n{e}")
+                Ok(_) => panic!(
+                    "The CLI didn't generate a help message for {args:?}, are the inputs correct?"
+                ),
+                Err(e) => assert_eq!(
+                    e.kind(),
+                    clap::error::ErrorKind::DisplayHelp,
+                    "The CLI emitted an error for {args:?}:\n{e}"
+                ),
             };
         }
         assert_shows_help(&["scaphandre", "--help"]);

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -20,7 +20,7 @@ use utils::{current_system_time_since_epoch, IProcess, ProcessTracker};
 // !!!!!!!!!!!!!!!!! Sensor !!!!!!!!!!!!!!!!!!!!!!!
 /// Sensor trait, the Sensor API.
 pub trait Sensor {
-    fn get_topology(&mut self) -> Box<Option<Topology>>;
+    fn get_topology(&self) -> Box<Option<Topology>>;
     fn generate_topology(&self) -> Result<Topology, Box<dyn Error>>;
 }
 
@@ -1452,9 +1452,9 @@ mod tests {
     #[test]
     fn read_topology_stats() {
         #[cfg(target_os = "linux")]
-        let mut sensor = powercap_rapl::PowercapRAPLSensor::new(8, 8, false);
+        let sensor = powercap_rapl::PowercapRAPLSensor::new(8, 8, false);
         #[cfg(not(target_os = "linux"))]
-        let mut sensor = msr_rapl::MsrRAPLSensor::new();
+        let sensor = msr_rapl::MsrRAPLSensor::new();
         let topo = (*sensor.get_topology()).unwrap();
         println!("{:?}", topo.read_stats());
     }
@@ -1462,9 +1462,9 @@ mod tests {
     #[test]
     fn read_core_stats() {
         #[cfg(target_os = "linux")]
-        let mut sensor = powercap_rapl::PowercapRAPLSensor::new(8, 8, false);
+        let sensor = powercap_rapl::PowercapRAPLSensor::new(8, 8, false);
         #[cfg(not(target_os = "linux"))]
-        let mut sensor = msr_rapl::MsrRAPLSensor::new();
+        let sensor = msr_rapl::MsrRAPLSensor::new();
         let mut topo = (*sensor.get_topology()).unwrap();
         for s in topo.get_sockets() {
             for c in s.get_cores() {
@@ -1476,9 +1476,9 @@ mod tests {
     #[test]
     fn read_socket_stats() {
         #[cfg(target_os = "linux")]
-        let mut sensor = powercap_rapl::PowercapRAPLSensor::new(8, 8, false);
+        let sensor = powercap_rapl::PowercapRAPLSensor::new(8, 8, false);
         #[cfg(not(target_os = "linux"))]
-        let mut sensor = msr_rapl::MsrRAPLSensor::new();
+        let sensor = msr_rapl::MsrRAPLSensor::new();
         let mut topo = (*sensor.get_topology()).unwrap();
         for s in topo.get_sockets() {
             println!("{:?}", s.read_stats());

--- a/src/sensors/msr_rapl.rs
+++ b/src/sensors/msr_rapl.rs
@@ -300,7 +300,7 @@ impl Sensor for MsrRAPLSensor {
         Ok(topology)
     }
 
-    fn get_topology(&mut self) -> Box<Option<Topology>> {
+    fn get_topology(&self) -> Box<Option<Topology>> {
         let topology = self.generate_topology().ok();
         if topology.is_none() {
             panic!("Couldn't generate the topology !");

--- a/src/sensors/powercap_rapl.rs
+++ b/src/sensors/powercap_rapl.rs
@@ -7,6 +7,9 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::{env, fs};
 
+pub const DEFAULT_BUFFER_PER_SOCKET_MAX_KBYTES: u16 = 1;
+pub const DEFAULT_BUFFER_PER_DOMAIN_MAX_KBYTES: u16 = 1;
+
 /// This is a Sensor type that relies on powercap and rapl linux modules
 /// to collect energy consumption from CPU sockets and RAPL domains
 pub struct PowercapRAPLSensor {
@@ -188,7 +191,7 @@ impl Sensor for PowercapRAPLSensor {
     }
 
     /// Instanciates Topology object if not existing and returns it
-    fn get_topology(&mut self) -> Box<Option<Topology>> {
+    fn get_topology(&self) -> Box<Option<Topology>> {
         let topology = self.generate_topology().ok();
         if topology.is_none() {
             panic!("Couldn't generate the topology !");
@@ -207,7 +210,7 @@ mod tests {
     }
     #[test]
     fn get_topology_returns_topology_type() {
-        let mut sensor = PowercapRAPLSensor::new(1, 1, false);
+        let sensor = PowercapRAPLSensor::new(1, 1, false);
         let topology = sensor.get_topology();
         assert_eq!(
             "alloc::boxed::Box<core::option::Option<scaphandre::sensors::Topology>>",

--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -182,15 +182,15 @@ impl IProcess {
     pub fn cgroups() {}
 }
 
-pub fn page_size() -> Result<i64, String> {
+pub fn page_size() -> Result<u64, String> {
     let res;
     #[cfg(target_os = "linux")]
     {
-        res = Ok(procfs::page_size().unwrap())
+        res = Ok(procfs::page_size())
     }
     #[cfg(target_os = "windows")]
     {
-        res = Ok(4096)
+        res = Ok(4096u64)
     }
     res
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,30 +1,24 @@
-//#[cfg(target_os = "linux")]
-//use scaphandre::exporters::qemu::QemuExporter;
-//#[cfg(target_os = "linux")]
-//use scaphandre::sensors::powercap_rapl::PowercapRAPLSensor;
-//use std::env::current_dir;
-//use std::fs::{create_dir, read_dir};
+#[cfg(target_os = "linux")]
+use scaphandre::exporters::qemu::QemuExporter;
+#[cfg(target_os = "linux")]
+use scaphandre::sensors::powercap_rapl::PowercapRAPLSensor;
+use std::env::current_dir;
+use std::fs::{create_dir, read_dir};
 
-//#[cfg(target_os = "linux")]
-//#[test]
-//fn exporter_qemu() {
-//    use scaphandre::{exporters::{MetricGenerator, utils::get_hostname}, sensors::Sensor};
-//
-//    let sensor = PowercapRAPLSensor::new(1, 1, false);
-//    let mut exporter = QemuExporter::new(Box::new(sensor));
-//    // Create integration_tests directory if it does not exist
-//    let curdir = current_dir().unwrap();
-//    let path = curdir.join("integration_tests");
-//    if !path.is_dir() {
-//        create_dir(&path).expect("Fail to create integration_tests directory");
-//    }
-//    // Convert to std::string::String
-//    let path = path.into_os_string().to_str().unwrap().to_string();
-//    if let Ok(mut topology) = &sensor.generate_topology() {
-//        let mut metric_generator = MetricGenerator::new(topology, get_hostname(), true, false);
-//        exporter.iteration(path.clone(), &mut metric_generator);
-//        let content = read_dir(path);
-//        assert_eq!(content.is_ok(), true);
-//    }
-//}
-//
+#[cfg(target_os = "linux")]
+#[test]
+fn exporter_qemu() {
+    let sensor = PowercapRAPLSensor::new(1, 1, false);
+    let mut exporter = QemuExporter::new(&sensor);
+    // Create integration_tests directory if it does not exist
+    let curdir = current_dir().unwrap();
+    let path = curdir.join("integration_tests");
+    if !path.is_dir() {
+        create_dir(&path).expect("Fail to create integration_tests directory");
+    }
+    // Convert to std::string::String
+    let path = path.into_os_string().to_str().unwrap().to_string();
+    exporter.iterate(path.clone());
+    let content = read_dir(path);
+    assert_eq!(content.is_ok(), true);
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,13 +1,11 @@
-#[cfg(target_os = "linux")]
-use scaphandre::exporters::qemu::QemuExporter;
-#[cfg(target_os = "linux")]
-use scaphandre::sensors::powercap_rapl::PowercapRAPLSensor;
-use std::env::current_dir;
-use std::fs::{create_dir, read_dir};
-
-#[cfg(target_os = "linux")]
+#[cfg(all(feature = "qemu", target_os = "linux"))]
 #[test]
 fn exporter_qemu() {
+    use scaphandre::exporters::qemu::QemuExporter;
+    use scaphandre::sensors::powercap_rapl::PowercapRAPLSensor;
+    use std::env::current_dir;
+    use std::fs::{create_dir, read_dir};
+
     let sensor = PowercapRAPLSensor::new(1, 1, false);
     let mut exporter = QemuExporter::new(&sensor);
     // Create integration_tests directory if it does not exist


### PR DESCRIPTION
This PR mainly **removes code**. It's a refactoring of how exporters are created.

Instead of using `Arg::new` and passing a `Vec<clap::Args>` around, one can simply define a struct with all the options and let `clap` do the work for us, thanks to the `derive` macro. This creates a cleaner separation between the exporters and the magagement of the CLI. This will be useful for #50 and #145.

## Command-line arguments handling

### Before

declaration:
```rust
fn get_options() -> Vec<clap::Arg> {
        let mut options = Vec::new();
        let arg = Arg::new("address")
            .default_value(DEFAULT_IP_ADDRESS)
            .help("Riemann ipv6 or ipv4 address. If mTLS is used then server fqdn must be provided")
            .long("address")
            .short('a')
            .required(false)
            .action(clap::ArgAction::Set);
        options.push(arg);

        let arg = Arg::new("port")
            .default_value(DEFAULT_PORT)
            .help("Riemann TCP port number")
            .long("port")
            .short('p')
            .required(false)
            .value_parser(value_parser!(u16))
            .action(clap::ArgAction::Set);
        options.push(arg);
    // and so on...
}
```
usage:
```rust
    let address = parameters.get_one::<String>("address").unwrap().to_string();
    let port: u16 = *parameters
        .get_one("port")
        .expect("Fail parsing port number");
```

### After

declaration:
```rust
#[derive(clap::Args, Debug)]
struct ExporterArgs {
    /// Address of the Riemann server. If mTLS is used this must be the server's FQDN.
    #[arg(short, long, default_value = DEFAULT_IP_ADDRESS)]
    pub address: String,

    /// TCP port number of the Riemann server
    #[arg(short, long, default_value_t = DEFAULT_PORT)]
    pub port: u16,

    // and so on...
}
```

usage:
```rust
let address = args.address; // simpler :)
let port = args.port; // the parsing is done by clap, it's already a u16
```

The documentation of the ExporterArgs structs is both for clap and for us. It shows up nicely in the IDE.
It's also easier to use this way.

## Exporter initialization from CLI

Before:
```rust
if let Some(stdout_exporter_parameters) = matches.subcommand_matches("stdout") {
    if header {
        scaphandre_header("stdout");
    }
    exporter_parameters = stdout_exporter_parameters.clone();
    let mut exporter = StdoutExporter::new(sensor_boxed);
    exporter.run(exporter_parameters);
} else if ...
// other conditions with duplicated code
```

After:
```rust
let exporter = match cli.exporter {
    ExporterChoice::Stdout(args) => StdoutExporter::new(sensor, args)
    // ...
}
exporter.run()
```

The code is now deduplicated, and it's easier to add a new exporter or sensor to Scaphandre.

## Exporter initialization without CLI (new)

The exporters can now be created without a command-line interface, by creating the `ExporterArgs` struct.
The new function `get_default_sensor` allows to get the RAPL sensor on Linux, with default params, and the MSR sensor on Windows.

```rust
use scaphandre::get_default_sensor;
use exporters::json::{ExporterArgs, JsonExporter};

let sensor = get_default_sensor();
let args = ExporterArgs { timeout: 1, step: 1, /* other fields omitted */ };
let mut exporter = JsonExporter::new(&sensor, args);
```

All exporters are used in the same way (there were some disparities before):
1. Create the exporter with `::new(sensor, args)`
2. Run it with `.run()`

This makes good progress towards #50.

## Summary of the advantages

- Good progress towards #50.
- Easier to add a new exporter or sensor (even for someone new to clap or new to Scaphandre)
- Less code, better checks and better error messages, such as:
```
❯ scaphandre riemann --mtls
error: the following required arguments were not provided:
  --address <ADDRESS>
  --ca <CA_FILE>
  --cert <CERT_FILE>
  --key <KEY_FILE>

Usage: scaphandre riemann --address <ADDRESS> --mtls --ca <CA_FILE> --cert <CERT_FILE> --key <KEY_FILE>

For more information, try '--help'.
```
without any code in Scaphandre doing the check!
- More errors are now catched when the exporter is created by `new()` instead of when it runs.

Bonus:
- Some code have been moved from the exporters' loops to their creation (`new`). For example, we don't need to recreate a warp10 `Client` on every iteration I think (correct me if I'm wrong). It's now created in `new`.
- The arguments' doc have been improved

## TODO

~~I'd like to add more integration tests before marking this as ready.~~ done :)