### PR TITLE
chore: remove unnecessary casts

### DIFF
--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -233,7 +233,7 @@ impl MetricGenerator {
         for p in &self.topology.proc_tracker.procs {
             if p.len() > 1 {
                 let diff = self.topology.proc_tracker.get_cpu_usage_percentage(
-                    p.first().unwrap().process.pid as _,
+                    p.first().unwrap().process.pid,
                     self.topology.proc_tracker.nb_cores,
                 );
                 let p_record = p.last().unwrap();

--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -674,12 +674,12 @@ impl ProcessTracker {
         let mut consumers: Vec<(IProcess, OrderedFloat<f64>)> = vec![];
         for p in &self.procs {
             if p.len() > 1 {
-                let diff = self
-                    .get_cpu_usage_percentage(p.first().unwrap().process.pid as _, self.nb_cores);
+                let diff =
+                    self.get_cpu_usage_percentage(p.first().unwrap().process.pid, self.nb_cores);
                 if consumers
                     .iter()
                     .filter(|x| {
-                        if let Some(p) = self.sysinfo.process(x.0.pid as _) {
+                        if let Some(p) = self.sysinfo.process(x.0.pid) {
                             return p.cpu_usage() > diff;
                         }
                         false
@@ -688,7 +688,7 @@ impl ProcessTracker {
                     < top as usize
                 {
                     let pid = p.first().unwrap().process.pid;
-                    if let Some(sysinfo_process) = self.sysinfo.process(pid as _) {
+                    if let Some(sysinfo_process) = self.sysinfo.process(pid) {
                         let new_consumer = IProcess::new(sysinfo_process);
                         consumers.push((new_consumer, OrderedFloat(diff as f64)));
                         consumers.sort_by(|x, y| y.1.cmp(&x.1));
@@ -713,8 +713,8 @@ impl ProcessTracker {
         let mut consumers: Vec<(IProcess, OrderedFloat<f64>)> = vec![];
         for p in &self.procs {
             if p.len() > 1 {
-                let diff = self
-                    .get_cpu_usage_percentage(p.first().unwrap().process.pid as _, self.nb_cores);
+                let diff =
+                    self.get_cpu_usage_percentage(p.first().unwrap().process.pid, self.nb_cores);
                 let p_record = p.last().unwrap();
                 let process_exe = p_record.process.exe(self).unwrap_or_default();
                 let process_cmdline = p_record.process.cmdline(self).unwrap_or_default();


### PR DESCRIPTION
`get_cpu_usage_percentage()` and `sysinfo.process()` both take a `Pid`, so the `pid as _` casts are unnecessary.