### PR TITLE
feat: Add extra labels on serviceMonitor + allow toleration configuration on helm chart

### DIFF
--- a/docs_src/tutorials/kubernetes.md
+++ b/docs_src/tutorials/kubernetes.md
@@ -15,12 +15,13 @@ to be installed from the source code.
 ### Parameters
 #### Service monitor parameters
 
-| Name                      | Description                                                                                   | Value                     |
-| ------------------------- | ----------------------------------------------------------------------------------------------| ------------------------- |
-| `serviceMonitor.enabled`  | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                  | `false`                   |
-| `serviceMonitor.namespace`| The namespace in which the ServiceMonitor will be created   (if not set, default to namespace on which this chart is installed)  | `""`                      |
-| `serviceMonitor.interval` | The interval at which metrics should be scraped                                               | `1m`                     |
-| `serviceMonitor.labels`   | Extra labels for the ServiceMonitor                                                           | `{}`                     |
+| Name                           | Description                                                                                   | Value                     |
+| ------------------------- -----| ----------------------------------------------------------------------------------------------| ------------------------- |
+| `serviceMonitor.enabled`       | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                  | `false`                   |
+| `serviceMonitor.namespace`     | The namespace in which the ServiceMonitor will be created   (if not set, default to namespace on which this chart is installed)  | `""`                      |
+| `serviceMonitor.interval`      | The interval at which metrics should be scraped                                               | `1m`                     |
+| `serviceMonitor.labels`        | Extra labels for the ServiceMonitor                                                           | `{}`                     |
+| `serviceMonitor.scrapeTimeout` | Specify the timeout after which the scrape is ended                                           | `30s`                    |
 
 #### Other parameters
 | Name                                       | Description                                                                 | Value                     |

--- a/docs_src/tutorials/kubernetes.md
+++ b/docs_src/tutorials/kubernetes.md
@@ -22,6 +22,7 @@ to be installed from the source code.
 | `serviceMonitor.interval`      | The interval at which metrics should be scraped                                               | `1m`                     |
 | `serviceMonitor.labels`        | Extra labels for the ServiceMonitor                                                           | `{}`                     |
 | `serviceMonitor.scrapeTimeout` | Specify the timeout after which the scrape is ended                                           | `30s`                    |
+| `serviceMonitor.relabelings`   | Allow to add extra labels to metrics                                                          | Add node metrics         |
 
 #### Other parameters
 | Name                                       | Description                                                                 | Value                     |

--- a/docs_src/tutorials/kubernetes.md
+++ b/docs_src/tutorials/kubernetes.md
@@ -25,9 +25,10 @@ to be installed from the source code.
 | `serviceMonitor.relabelings`   | Allow to add extra labels to metrics                                                          | Add node metrics         |
 
 #### Other parameters
-| Name                                       | Description                                                                 | Value                     |
-| ------------------------------------------ | ----------------------------------------------------------------------------| ------------------------- |
-| `tolerations`                              | Tolerations for pod assignment. Evaluated as a template.                    | `- operator: "Exists"`    |
+| Name                                       | Description                                                                                     | Value                     |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------| ------------------------- |
+| `affinity`                                 | Pod scheduling preference. Can be used for instance when some node does not support scaphandre. | `{}`                      |
+| `tolerations`                              | Tolerations for pod assignment. Evaluated as a template.                                        | `- operator: "Exists"`    |
 
 ## Install Prometheus
 

--- a/docs_src/tutorials/kubernetes.md
+++ b/docs_src/tutorials/kubernetes.md
@@ -15,11 +15,17 @@ to be installed from the source code.
 ### Parameters
 #### Service monitor parameters
 
-| Name                                       | Description                                                                                                     | Value                     |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                    | `false`                    |
-| `serviceMonitor.namespace`         | The namespace in which the ServiceMonitor will be created   (if not set, default to namespace on which this chart is installed)                                                    | `""`                      |
-| `serviceMonitor.interval`          | The interval at which metrics should be scraped                                                                 | `1m`                     |
+| Name                      | Description                                                                                   | Value                     |
+| ------------------------- | ----------------------------------------------------------------------------------------------| ------------------------- |
+| `serviceMonitor.enabled`  | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                  | `false`                   |
+| `serviceMonitor.namespace`| The namespace in which the ServiceMonitor will be created   (if not set, default to namespace on which this chart is installed)  | `""`                      |
+| `serviceMonitor.interval` | The interval at which metrics should be scraped                                               | `1m`                     |
+| `serviceMonitor.labels`   | Extra labels for the ServiceMonitor                                                           | `{}`                     |
+
+#### Other parameters
+| Name                                       | Description                                                                 | Value                     |
+| ------------------------------------------ | ----------------------------------------------------------------------------| ------------------------- |
+| `tolerations`                              | Tolerations for pod assignment. Evaluated as a template.                    | `- operator: "Exists"`    |
 
 ## Install Prometheus
 

--- a/helm/scaphandre/Chart.yaml
+++ b/helm/scaphandre/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.1.1
 description: A Helm chart for Scaphandre electrical power consumption agent
 home: https://github.com/hubblo-org/scaphandre
 name: scaphandre
-version: 0.1.0
+version: 0.1.1

--- a/helm/scaphandre/templates/daemonset.yaml
+++ b/helm/scaphandre/templates/daemonset.yaml
@@ -56,6 +56,10 @@ spec:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.userGroup }}
       serviceAccountName: {{ template "scaphandre.name" . }}
+      affinity:
+        {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/scaphandre/templates/daemonset.yaml
+++ b/helm/scaphandre/templates/daemonset.yaml
@@ -56,9 +56,10 @@ spec:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.userGroup }}
       serviceAccountName: {{ template "scaphandre.name" . }}
+    {{- with .Values.tolerations }}
       tolerations:
-      # Tolerate all taints for observability
-      - operator: "Exists"
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       volumes:
       - hostPath:
           path: /proc

--- a/helm/scaphandre/templates/servicemonitor.yaml
+++ b/helm/scaphandre/templates/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
       {{- if .Values.serviceMonitor.interval }}
       interval: {{ .Values.serviceMonitor.interval }}
       {{- end }}
-      scrapeTimeout: 30s
+      scrapeTimeout:  {{ .Values.serviceMonitor.scrapeTimeout }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/helm/scaphandre/templates/servicemonitor.yaml
+++ b/helm/scaphandre/templates/servicemonitor.yaml
@@ -9,7 +9,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
-    app.kubernetes.io/name: {{ template "scaphandre.name" . }}
+    {{- include "labels.common" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - path: /metrics

--- a/helm/scaphandre/templates/servicemonitor.yaml
+++ b/helm/scaphandre/templates/servicemonitor.yaml
@@ -22,6 +22,10 @@ spec:
       interval: {{ .Values.serviceMonitor.interval }}
       {{- end }}
       scrapeTimeout:  {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+          {{ toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/helm/scaphandre/values.yaml
+++ b/helm/scaphandre/values.yaml
@@ -32,6 +32,9 @@ serviceMonitor:
   # Extra labels for the ServiceMonitor
   labels: {}
 
+  # Specify the timeout after which the scrape is ended
+  scrapeTimeout: 30s
+
 tolerations:
   # Tolerate all taints for observability
   - operator: "Exists"

--- a/helm/scaphandre/values.yaml
+++ b/helm/scaphandre/values.yaml
@@ -28,3 +28,10 @@ serviceMonitor:
   interval: 1m
   # Specifies namespace, where ServiceMonitor should be installed
   # namespace: monitoring
+
+  # Extra labels for the ServiceMonitor
+  labels: {}
+
+tolerations:
+  # Tolerate all taints for observability
+  - operator: "Exists"

--- a/helm/scaphandre/values.yaml
+++ b/helm/scaphandre/values.yaml
@@ -15,7 +15,7 @@ scaphandre:
   command: prometheus
   args: {}
   extraArgs:
-    containers:
+    containers: null
 #  rustBacktrace: '1'
 
 # Run as root user to get proper permissions
@@ -34,6 +34,12 @@ serviceMonitor:
 
   # Specify the timeout after which the scrape is ended
   scrapeTimeout: 30s
+
+  relabelings:
+  - action: replace
+    sourceLabels:
+      - __meta_kubernetes_pod_node_name
+    targetLabel: node
 
 tolerations:
   # Tolerate all taints for observability

--- a/helm/scaphandre/values.yaml
+++ b/helm/scaphandre/values.yaml
@@ -41,6 +41,8 @@ serviceMonitor:
       - __meta_kubernetes_pod_node_name
     targetLabel: node
 
+affinity: {}
+
 tolerations:
   # Tolerate all taints for observability
   - operator: "Exists"


### PR DESCRIPTION
Improve helm chart in order to 
- allow to define extra labels on serviceMonitor
- allow toleration configuration (In my case, I want to exclude the master as it is a VM not compatible with scaphandre)

@damienvergnaud does this PR fit your needs ?

@bpetit in https://github.com/hubblo-org/scaphandre/pull/230  the serviceMonitor.interval is set by default to 1m, this may be too hight. In our deployment I changed it to 5 minutes else scaphandre took too much CPU. Do you think, that default value should be changed ?