### PR TITLE
fix: Don't use value for --containers flag in chart

### DIFF
--- a/helm/scaphandre/values.yaml
+++ b/helm/scaphandre/values.yaml
@@ -15,7 +15,7 @@ scaphandre:
   command: prometheus
   args: {}
   extraArgs:
-    containers: true
+    containers:
 #  rustBacktrace: '1'
 
 # Run as root user to get proper permissions


### PR DESCRIPTION
Hi @bpetit,
I found a problem with the dev branch and the --containers flag.

Removing the true value fixes it and I tested with both the dev and latest branches and it works with both. 

```
kubectl get pods

NAME               READY   STATUS             RESTARTS     AGE
scaphandre-v7wh6   0/1     CrashLoopBackOff   1 (3s ago)   5s


kubectl logs scaphandre-v7wh6
error: unexpected value 'true' for '--containers' found; no more were expected

Usage: scaphandre prometheus --containers

For more information, try '--help'.
```