### PR TITLE
fix: Kubernetes integration when using cgroups v2

### DIFF
--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -430,7 +430,10 @@ impl ProcessTracker {
             container_id = container_id.split(':').last().unwrap().to_string();
         }
         if container_id.starts_with("cri-containerd-") {
-            container_id = container_id.strip_prefix("cri-containerd-").unwrap().to_string();
+            container_id = container_id
+                .strip_prefix("cri-containerd-")
+                .unwrap()
+                .to_string();
         }
         Ok(container_id)
     }

--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -246,7 +246,7 @@ impl ProcessTracker {
         #[cfg(feature = "containers")]
         let regex_cgroup_docker = Regex::new(r"^.*/docker.*$").unwrap();
         #[cfg(feature = "containers")]
-        let regex_cgroup_kubernetes = Regex::new(r"^/kubepods.*$").unwrap();
+        let regex_cgroup_kubernetes = Regex::new(r"/kubepods.*$").unwrap();
         #[cfg(feature = "containers")]
         let regex_cgroup_containerd = Regex::new("/system.slice/containerd.service/.*$").unwrap();
 
@@ -428,6 +428,9 @@ impl ProcessTracker {
         }
         if container_id.contains("cri-containerd") {
             container_id = container_id.split(':').last().unwrap().to_string();
+        }
+        if container_id.starts_with("cri-containerd-") {
+            container_id = container_id.strip_prefix("cri-containerd-").unwrap().to_string();
         }
         Ok(container_id)
     }


### PR DESCRIPTION
Hi @bpetit,
I had a problem when testing with ubuntu:22.04 since it uses cgroups v2.

The paths are now relative so I needed to remove the `^` from the regex.

```
/../../../kubepods-besteffort.slice/kubepods-besteffort-pod43a7b130_2354_4564_9628_554d82403c6f.slice/cri-containerd-339bb32e778c77fcfdf986785997959e4519dfdca5b9100d06aa00685145ce85.scope
```

I also tested with ubuntu:20.04 to check compatibility with cgroups v1.