### PR TITLE
Warn on energy reading error

### DIFF
--- a/docs_src/troubleshooting.md
+++ b/docs_src/troubleshooting.md
@@ -1,8 +1,8 @@
 # Troubleshooting
 
-### I get a **permission denied** error when I run scaphandre, no matter what is the exporter
+### I get a "Couldn't read energy consumption: Permission denied (os error 13)"
 
-On some Linux distributions (ubuntu 20.04 for sure), the energy counters files that the [PowercapRAPL sensor](references/sensor-powercap_rapl.md) uses, are owned by root. (since late 2020)
+Since Linux kernel 5.10 (late 2020), the energy counters files that the [PowercapRAPL sensor](references/sensor-powercap_rapl.md) uses, are owned by root.
 
 To ensure this is your issue and fix that quickly you can run the [init.sh](https://raw.githubusercontent.com/hubblo-org/scaphandre/main/init.sh) script:
 

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -672,6 +672,14 @@ impl Topology {
     }
 }
 
+fn warn_error_reading_sensor(err: Box<dyn Error>) {
+    warn!(
+        "Couldn't read energy consumption: {err}. \
+        You may need to check: \
+        https://hubblo-org.github.io/scaphandre-documentation/troubleshooting.html#i-get-a-couldnt-read-energy-consumption-permission-denied-os-error-13"
+    )
+}
+
 // !!!!!!!!!!!!!!!!! CPUSocket !!!!!!!!!!!!!!!!!!!!!!!
 /// CPUSocket struct represents a CPU socket (matches physical_id attribute in /proc/cpuinfo),
 /// owning CPU cores (processor in /proc/cpuinfo).
@@ -703,8 +711,11 @@ impl RecordGenerator for CPUSocket {
     /// Returns a clone of this Record instance.
     fn refresh_record(&mut self) {
         //if let Ok(record) = self.read_record_uj() {
-        if let Ok(record) = self.read_record() {
-            self.record_buffer.push(record);
+        match self.read_record() {
+            Ok(record) => {
+                self.record_buffer.push(record);
+            }
+            Err(err) => warn_error_reading_sensor(err)
         }
 
         if !self.record_buffer.is_empty() {
@@ -1043,8 +1054,11 @@ impl RecordGenerator for Domain {
     /// stores a copy in self.record_buffer and returns it.
     fn refresh_record(&mut self) {
         //if let Ok(record) = self.read_record_uj() {
-        if let Ok(record) = self.read_record() {
-            self.record_buffer.push(record);
+        match self.read_record() {
+            Ok(record) => {
+                self.record_buffer.push(record);
+            }
+            Err(err) => warn_error_reading_sensor(err),
         }
 
         if !self.record_buffer.is_empty() {


### PR DESCRIPTION
Since Linux commit [949dd0104c496fa7c14991a23c03c62e44637e71](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=949dd0104c496fa7c14991a23c03c62e44637e71) (and Linux 5.10) access to `energy_uj` is forbidden for non-priviledged users to prevent cryptographic side-channel attacks.

This is correctly identified in the doc here: https://hubblo-org.github.io/scaphandre-documentation/troubleshooting.html#i-get-a-permission-denied-error-when-i-run-scaphandre-no-matter-what-is-the-exporter but the doc is outdated.

On my machine I get no error on sensors unavailability but all readings are instead 0. 

This PR produces a warning on unavailable reading and updates the doc accordingly.