### PR TITLE
Create Debian package with version tag

### DIFF
--- a/.github/workflows/debian-release.yml
+++ b/.github/workflows/debian-release.yml
@@ -1,7 +1,7 @@
 name: debian-release
 
 on:
-  push:
+  release:
     paths-ignore:
       - 'docs_src/**'
       - 'README.md'
@@ -9,6 +9,7 @@ on:
       - 'book.toml'
       - 'CONTRIBUTING.md'
     tags: [ 'v*.*.*', 'dev*.*.*' ]
+    types: [published]                                                                      
 
 env:
   VERSION: ${{ vars.GITHUB_REF_NAME }}
@@ -28,4 +29,4 @@ jobs:
         ./build.sh -v {{ $VERSION }}
     - name: Build package with version tag and Debian 12 Bookworm
       run: |
-        $IMAGE="debian:bookworm-slim" ./build.sh -v {{ $VERSION }}
+        ./build.sh  -i debian:bookworm-slim -v {{ $VERSION }}

--- a/.github/workflows/debian-release.yml
+++ b/.github/workflows/debian-release.yml
@@ -1,0 +1,11 @@
+name: debian-release
+
+on:
+  push:
+    paths-ignore:
+      - 'docs_src/**'
+      - 'README.md'
+      - 'CITATION'
+      - 'book.toml'
+      - 'CONTRIBUTING.md'
+    tags: [ 'v*.*.*', 'dev*.*.*' ]

--- a/.github/workflows/debian-release.yml
+++ b/.github/workflows/debian-release.yml
@@ -9,3 +9,23 @@ on:
       - 'book.toml'
       - 'CONTRIBUTING.md'
     tags: [ 'v*.*.*', 'dev*.*.*' ]
+
+env:
+  VERSION: ${{ vars.GITHUB_REF_NAME }}
+
+
+jobs:
+  create_debian_pkg_with_tag:
+    name: Create Debian package associated to version tag
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout scaphandre-debian repository
+      uses: actions/checkout@v4
+      with:
+        repository: 'barnumbirr/scaphandre-debian'
+    - name: Build package with version tag and Debian 11 Bullseye
+      run : |
+        ./build.sh -v {{ $VERSION }}
+    - name: Build package with version tag and Debian 12 Bookworm
+      run: |
+        $IMAGE="debian:bookworm-slim" ./build.sh -v {{ $VERSION }}

--- a/.github/workflows/debian-release.yml
+++ b/.github/workflows/debian-release.yml
@@ -1,7 +1,7 @@
-name: debian-release
+name: Build Debian package on release
 
 on:
-  release:
+  push:
     paths-ignore:
       - 'docs_src/**'
       - 'README.md'
@@ -9,24 +9,97 @@ on:
       - 'book.toml'
       - 'CONTRIBUTING.md'
     tags: [ 'v*.*.*', 'dev*.*.*' ]
-    types: [published]                                                                      
-
-env:
-  VERSION: ${{ vars.GITHUB_REF_NAME }}
 
 
 jobs:
   create_debian_pkg_with_tag:
     name: Create Debian package associated to version tag
     runs-on: ubuntu-latest
+    outputs:
+      deb11output: ${{ steps.deb11pkgname.outputs.deb11pkg }}
+      deb12output: ${{ steps.deb12pkgname.outputs.deb12pkg }}
     steps:
+    - name: Install s3cmd
+      run: sudo apt install python3-pip -y && sudo pip3 install s3cmd awxkit
+    - name: Checkout scaphandre repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Get latest tag of scaphandre repository
+      id: latest-scaphandre-tag
+      uses: "WyriHaximus/github-action-get-previous-tag@v1.3.0"
+      with:
+        fallback: dev0.5.18
     - name: Checkout scaphandre-debian repository
       uses: actions/checkout@v4
       with:
-        repository: 'barnumbirr/scaphandre-debian'
+        repository: hubblo-org/scaphandre-debian
     - name: Build package with version tag and Debian 11 Bullseye
       run : |
-        ./build.sh -v {{ $VERSION }}
+        ./build.sh -v ${{ steps.latest-scaphandre-tag.outputs.tag }}
+    - name: Modify name of package to include tag version for Debian 11
+      id: deb11pkgname
+      run: |
+        cd target
+        PKG_NAME=$(ls | sed "s/\([0-9]\+\.\)\{2\}[0-9]\+\-[0-9]\+\?/${{ steps.latest-scaphandre-tag.outputs.tag }}-deb11/")
+        mv *.deb $PKG_NAME
+        echo "deb11pkg=$PKG_NAME" >> "$GITHUB_OUTPUT"
+    - name: Upload to scw s3 and remove package
+      run: |
+        cd target
+        s3cmd --access_key="${{ secrets.S3_ACCESS_KEY_ID }}" --secret_key="${{ secrets.S3_SECRET_ACCESS_KEY }}" --region="fr-par" --acl-public --host="s3.fr-par.scw.cloud" --host-bucket="%(bucket).s3.fr-par.scw.cloud" put ${{ steps.deb11pkgname.outputs.deb11pkg }} s3://scaphandre/x86_64/
+        rm *.deb
     - name: Build package with version tag and Debian 12 Bookworm
       run: |
-        ./build.sh  -i debian:bookworm-slim -v {{ $VERSION }}
+        ./build.sh -i debian:bookworm-slim -v ${{ steps.latest-scaphandre-tag.outputs.tag }}
+    - name: Modify name of package to include tag version for Debian 12
+      id: deb12pkgname
+      run: |
+        cd target
+        PKG_NAME=$(ls | sed "s/\([0-9]\+\.\)\{2\}[0-9]\+\-[0-9]\+\?/${{ steps.latest-scaphandre-tag.outputs.tag }}-deb12/")
+        mv *.deb $PKG_NAME
+        echo "deb12pkg=$PKG_NAME" >> "$GITHUB_OUTPUT"
+    - name: Upload to scw s3
+      run: |
+        cd target
+        s3cmd --access_key="${{ secrets.S3_ACCESS_KEY_ID }}" --secret_key="${{ secrets.S3_SECRET_ACCESS_KEY }}" --region="fr-par" --acl-public --host="s3.fr-par.scw.cloud" --host-bucket="%(bucket).s3.fr-par.scw.cloud" put ${{ steps.deb12pkgname.outputs.deb12pkg }} s3://scaphandre/x86_64/
+  deb11-container-install-scaphandre:
+    name: Create Debian 11 container and install scaphandre with URL
+    needs: create_debian_pkg_with_tag
+    env:
+      DEB11PKG: ${{ needs.create_debian_pkg_with_tag.outputs.deb11output }}
+    runs-on: ubuntu-latest
+    container:
+      image: debian:buster-slim
+    steps:
+      - name: Install dependencies
+        run: |
+          apt update
+          apt install -y curl
+      - name: Download Debian 11 scaphandre package
+        run: |
+          curl -O https://s3.fr-par.scw.cloud/scaphandre/x86_64/${{ env.DEB11PKG }}
+      - name: Install and show scaphandre version
+        run: |
+          apt install -y ./${{ env.DEB11PKG }}
+          scaphandre -V
+  deb12-container-install-scaphandre:
+    name: Create Debian 12 container and install scaphandre with URL
+    needs: create_debian_pkg_with_tag
+    runs-on: ubuntu-latest
+    env:
+      DEB12PKG: ${{ needs.create_debian_pkg_with_tag.outputs.deb12output }}
+    container:
+      image: debian:bookworm-slim
+    steps:
+      - name: Install dependencies
+        run: |
+          apt update
+          apt install -y curl
+      - name: Download Debian 12 scaphandre package
+        run: |
+          curl -O https://s3.fr-par.scw.cloud/scaphandre/x86_64/${{ env.DEB12PKG }}
+      - name: Install and show scaphandre version
+        run: |
+          apt install -y ./${{ env.DEB12PKG }}
+          scaphandre -V


### PR DESCRIPTION
This pull request aims to add an automatic Debian package generation for the associated version tag through a GitHub Actions workflow. It will check the correct build of the package for Debian 11 ('bullseye') and 12 ('bookwork') and their installation on those distributions. It is built with the help of [barnumbirr's repository](https://github.com/barnumbirr/scaphandre-debian/). 