### PR TITLE
fix: fixing gitignore for intellij

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ packaging/*/BUILDROOT/*
 packaging/*/BUILDROOT/*
 
 .vscode
+
+.idea/


### PR DESCRIPTION
Hi there,

Side note: thanks for the cool talk at FOSDEM, really interesting.

This PR is just an additional ignore entry for the `.idea` folder created by IntelliJ (and other Jetbrain's products I believe).