### PR TITLE
feat: add actual process name to attributes - refs #367

### DIFF
--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -926,10 +926,11 @@ impl MetricGenerator {
 
         for pid in self.topology.proc_tracker.get_alive_pids() {
             let exe = self.topology.proc_tracker.get_process_name(pid);
+            let name = self.topology.proc_tracker.get_process_os_name(pid);
             let cmdline = self.topology.proc_tracker.get_process_cmdline(pid);
 
             let mut attributes = HashMap::new();
-            debug!("Working on {}: {}", pid, exe);
+            debug!("Working on {}: {}", pid, name);
 
             #[cfg(feature = "containers")]
             if self.watch_containers && (!self.containers.is_empty() || !self.pods.is_empty()) {
@@ -954,6 +955,8 @@ impl MetricGenerator {
             attributes.insert("pid".to_string(), pid.to_string());
 
             attributes.insert("exe".to_string(), exe.clone());
+
+            attributes.insert("name".to_string(), name.clone());
 
             if let Some(cmdline_str) = cmdline {
                 attributes.insert("cmdline".to_string(), utils::filter_cmdline(&cmdline_str));

--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -69,6 +69,7 @@ pub struct IStatus {
 pub struct IProcess {
     pub pid: Pid,
     pub owner: u32,
+    pub name: String,
     pub comm: String,
     pub cmdline: Vec<String>,
     //CPU (all of them) time usage, as a percentage
@@ -109,6 +110,7 @@ impl IProcess {
             IProcess {
                 pid: process.pid(),
                 owner: 0,
+                name: process.name().to_string(),
                 comm: String::from(process.exe().to_str().unwrap()),
                 cmdline: process.cmd().to_vec(),
                 cpu_usage_percentage: process.cpu_usage(),
@@ -127,6 +129,7 @@ impl IProcess {
             IProcess {
                 pid: process.pid(),
                 owner: 0,
+                name: process.name().to_string(),
                 comm: String::from(process.exe().to_str().unwrap()),
                 cmdline: process.cmd().to_vec(),
                 cpu_usage_percentage: process.cpu_usage(),
@@ -635,6 +638,21 @@ impl ProcessTracker {
 
         debug!("End of get process name.");
         process.first().unwrap().process.comm.clone()
+    }
+
+    /// Returns the OS process name associated to a PID
+    pub fn get_process_os_name(&self, pid: Pid) -> String {
+        let mut result = self
+            .procs
+            .iter()
+            .filter(|x| !x.is_empty() && x.first().unwrap().process.pid == pid);
+        let process = result.next().unwrap();
+        if result.next().is_some() {
+            panic!("Found two vectors of processes with the same id, maintainers should fix this.");
+        }
+
+        debug!("End of get process os name.");
+        process.first().unwrap().process.name.clone()
     }
 
     /// Returns the cmdline string associated to a PID


### PR DESCRIPTION
This change adds new process-level attribute `name`, which (especially on Linux/Unix platforms) never seems to be empty, in contrast to `exe` or `cmdline`.

Although the name of a process can be changed arbitrarily, it sometimes is the only way to get to display something.

Most notably, all the processes crated by the Linux kernel and its drivers would usually not get any name or label.

Now, the name allows to handle these in monitoring tools, e.g. for Prometheus:
```
scaph_process_power_consumption_microwatts{name="kworker/u64:8-kcryptd/254:0",pid="18481",cmdline="",exe=""} 393.04565762067216
scaph_process_power_consumption_microwatts{pid="487",exe="",name="dmcrypt_write/254:0",cmdline=""} 131.01521494421178
scaph_process_power_consumption_microwatts{pid="15227",exe="",name="kworker/u64:15-kcryptd/254:0",cmdline=""} 262.03042988842355
scaph_process_power_consumption_microwatts{exe="",pid="17026",cmdline="",name="kworker/u64:3-kcryptd/254:0"} 917.1065429735929
scaph_process_power_consumption_microwatts{pid="18553",cmdline="",exe="",name="kworker/u64:10-kcryptd/254:0"} 262.03042988842355
```
