### PR TITLE
Add Qemu back to the list of features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ core_affinity = { version = "0.8.1"}
 x86 = { version = "0.52.0" }
 
 [features]
-default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush"]
+default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush", "qemu"]
 prometheus = ["hyper", "tokio"]
 riemann = ["riemann_client"]
 json = ["serde", "serde_json"]


### PR DESCRIPTION
For some reason Qemu is not in the list of features in Cargo.toml, making it unavailable to anyone using 1.0.0, even though it is referenced in the documentation.

I tried to look around for any discussions as to why this feature was disabled. I could not find any so I'm making the assumption that this was not deliberate and possibly happened due to a merge conflict.