### PR TITLE
Add support for native KVM driver VMs in the Qemu exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ core_affinity = { version = "0.8.1"}
 x86 = { version = "0.52.0" }
 
 [features]
-default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush"]
+default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush", "qemu"]
 prometheus = ["hyper", "tokio"]
 riemann = ["riemann_client"]
 json = ["serde", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 ordered-float = "2.0"
 warp10 = { version = "2.0.0", optional = true }
-rand = { version = "0.7.3" }
 time = "0.3"
 colored = "2.0"
 chrono = "0.4"
@@ -33,6 +32,7 @@ hyper = { version = "0.14", features = ["full"], optional = true }
 tokio = { version = "1.26.0", features = ["full"], optional = true}
 sysinfo = { version = "0.28.3"}
 isahc = { version = "1.7.2", optional = true }
+ctrlc = { version = "3.4", features = [ "termination" ] }
 
 [target.'cfg(target_os="linux")'.dependencies]
 procfs = { version = "0.15.0" }
@@ -45,7 +45,7 @@ core_affinity = { version = "0.8.1"}
 x86 = { version = "0.52.0" }
 
 [features]
-default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush","qemu"]
+default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush"]
 prometheus = ["hyper", "tokio"]
 riemann = ["riemann_client"]
 json = ["serde", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 ordered-float = "2.0"
 warp10 = { version = "2.0.0", optional = true }
+rand = { version = "0.7.3" }
 time = "0.3"
 colored = "2.0"
 chrono = "0.4"
@@ -32,7 +33,6 @@ hyper = { version = "0.14", features = ["full"], optional = true }
 tokio = { version = "1.26.0", features = ["full"], optional = true}
 sysinfo = { version = "0.28.3"}
 isahc = { version = "1.7.2", optional = true }
-ctrlc = { version = "3.4", features = [ "termination" ] }
 
 [target.'cfg(target_os="linux")'.dependencies]
 procfs = { version = "0.15.0" }
@@ -45,7 +45,7 @@ core_affinity = { version = "0.8.1"}
 x86 = { version = "0.52.0" }
 
 [features]
-default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush"]
+default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush","qemu"]
 prometheus = ["hyper", "tokio"]
 riemann = ["riemann_client"]
 json = ["serde", "serde_json"]

--- a/docs_src/how-to_guides/propagate-metrics-hypervisor-to-vm_qemu-kvm.md
+++ b/docs_src/how-to_guides/propagate-metrics-hypervisor-to-vm_qemu-kvm.md
@@ -55,6 +55,26 @@ You can now run scaphandre to export the metrics with the exporter of your choic
 
      scaphandre --vm prometheus
 
+## How to expose metrics in PROXMOX Virtual Environment
+   
+Run scaphandre with the qemu exporter on your bare metal hypervisor machine:
+	
+	scaphandre qemu
+
+The Qemu exporter will expose virtual machine metrics in `/var/lib/libvirt/scaphandre/${VM_NAME}` with `VM_NAME` being the name of the virtual machine (VM).
+Add the following line at the end of the `/etc/pve/qemu-server/${<VM_ID}.conf` file, with `VM_ID` being the ID that PROXMOX has assigned your VM.
+
+	args: -fsdev local,security_model=passthrough,id=fsdev0,path=/var/lib/libvirt/scaphandre/${VM_NAME} -device virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=${VM_NAME}
+
+If you perform this file change with the VM running, you need to restart it for this modification to take effect.
+In the guest (VM), mount the required directory in Read-Only mode:
+
+	mount -t 9p -o ro,trans=virtio,version=9p2000.L ${VM_NAME} /var/scaphandre
+
+Still in the guest, run scaphandre in VM mode with the default sensor:
+
+	scaphandre --vm prometheus
+ 
 Please refer to the [qemu exporter](../references/exporter-qemu.md) reference for more details.
 
-**Note:** This how to is only suitable for a "manual" use case. For all automated systems like openstack or proxmox, some more work needs to be done to make the integration of those steps easier.
+**Note:** This how to is only suitable for a "manual" use case. For automated systems like openstack, some more work needs to be done to make the integration of those steps easier.

--- a/docs_src/references/exporter-qemu.md
+++ b/docs_src/references/exporter-qemu.md
@@ -47,3 +47,25 @@ First create a tmpfs mount point to isolate metrics for that virtual machine:
     		scaphandre --vm prometheus
 
     6. Collect your virtual machine specific power usage metrics. (requesting http://VM_IP:8080/metrics in this example, using the prometheus exporter)
+  
+## Usage (PROXMOX VIM)
+   
+1. Run scaphandre with the qemu exporter on your bare metal hypervisor machine:
+	
+		scaphandre qemu # this is suitable for a test, please run it as a systemd service for a production setup
+
+2. Default is to expose virtual machines metrics in `/var/lib/libvirt/scaphandre/${VM_NAME}` with `VM_NAME` being the name of the virtual machine (VM).
+First, add the following line at the end of the `/etc/pve/qemu-server/${<VM_ID}.conf` file, with `VM_ID` being the ID that PROXMOX has assigned your VM.
+
+		args: -fsdev local,security_model=passthrough,id=fsdev0,path=/var/lib/libvirt/scaphandre/${VM_NAME} -device virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=${VM_NAME}
+
+3. If you perform this file change with the VM running, you need to restart it for this modification to take effect.
+4. In the guest (VM), mount the required directory in Read-Only mode:
+
+		mount -t 9p -o ro,trans=virtio,version=9p2000.L ${VM_NAME} /var/scaphandre
+
+5. Still in the guest, run scaphandre in VM mode with the default sensor:
+
+		scaphandre --vm prometheus
+
+6. Collect your virtual machine specific power usage metrics. (requesting http://${VM_IP}:8080/metrics in this example, using the prometheus exporter)

--- a/src/exporters/qemu.rs
+++ b/src/exporters/qemu.rs
@@ -24,7 +24,7 @@ impl Exporter for QemuExporter {
         let mut timer = time::Duration::from_secs(cleaner_step);
         loop {
             self.iterate(String::from(path));
-            let step = time::Duration::from_secs(5);
+            let step = time::Duration::from_secs(1);
             thread::sleep(step);
             if timer - step > time::Duration::from_millis(0) {
                 timer -= step;

--- a/src/exporters/qemu.rs
+++ b/src/exporters/qemu.rs
@@ -101,6 +101,13 @@ impl QemuExporter {
     /// Parses a cmdline String (as contained in procs::Process instances) and returns
     /// the name of the qemu virtual machine if this process is a qemu/kvm guest process
     fn get_vm_name_from_cmdline(cmdline: &[String]) -> String {
+        //If native KVM driver
+        for i in 0..cmdline.len() {
+          if cmdline[i].starts_with("-name") {
+            return String::from(cmdline[i+1].split(',').next().unwrap());
+          }
+        }
+        //If using qemu-system
         for elmt in cmdline {
             if elmt.starts_with("guest=") {
                 let mut splitted = elmt.split('=');
@@ -142,7 +149,7 @@ impl QemuExporter {
                         .process
                         .cmdline
                         .iter()
-                        .find(|x| x.contains("qemu-system"))
+                        .find(|x| x.contains("qemu-system") | x.contains("/usr/bin/kvm"))
                     {
                         debug!("Found a process with {}", res);
                         let mut tmp: Vec<ProcessRecord> = vec![];


### PR DESCRIPTION
Added support for exposing metrics to native KVM driver VMs (e.g., PROXMOX VE). Furthermore, updated the documentation to reflect this support.
Tested using PROXMOX VE 8.2.2