### PR TITLE
Fix/#347 missing kubernetes pods metric labels

### DIFF
--- a/src/exporters/utils.rs
+++ b/src/exporters/utils.rs
@@ -136,8 +136,9 @@ pub fn get_docker_client() -> Result<Docker, std::io::Error> {
 
 #[cfg(feature = "containers")]
 pub fn get_kubernetes_client() -> Result<Kubernetes, KubernetesError> {
+    let kube_config_path = dbg!(std::env::var("KUBECONFIG").ok());
     match Kubernetes::connect(
-        Some(String::from("/root/.kube/config")),
+        kube_config_path,
         None,
         None,
         None,

--- a/src/exporters/utils.rs
+++ b/src/exporters/utils.rs
@@ -136,7 +136,7 @@ pub fn get_docker_client() -> Result<Docker, std::io::Error> {
 
 #[cfg(feature = "containers")]
 pub fn get_kubernetes_client() -> Result<Kubernetes, KubernetesError> {
-    let kube_config_path = dbg!(std::env::var("KUBECONFIG").ok());
+    let kube_config_path = std::env::var("KUBECONFIG").ok();
     match Kubernetes::connect(
         kube_config_path,
         None,

--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -428,6 +428,11 @@ impl ProcessTracker {
         }
         if container_id.contains("cri-containerd") {
             container_id = container_id.split(':').last().unwrap().to_string();
+            // cgroup name sometimes look like cri-containerd-[actual container_id] so we take
+            // that into account
+            if container_id.contains("cri-containerd") {
+                container_id = container_id.split('-').last().unwrap().to_string();
+            }
         }
         Ok(container_id)
     }


### PR DESCRIPTION
Cgroups were sometimes incorrectly parsed which made it fail to correlate withe the pod's name when running with container support (at least that was the case for k3s).

It may be relevant to add a config for that as the name of the cgroup sometimes varies from one kubernetes distro to another.