### PR TITLE
feat: Publish helm chart as OCI artifact

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,36 @@
+name: helm_release
+
+on:
+  push:
+    paths-ignore:
+      - 'docs_src/**'
+      - 'README.md'
+      - 'CITATION'
+      - 'book.toml'
+      - 'CONTRIBUTING.md'
+      - '*.md'
+      - 'oranda.json'
+    tags: [ 'v*.*.*' ]
+
+jobs:
+  package_and_push:
+    name: package_and_push_helm_chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+      - name: Login to DockerHub
+        run: |
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | helm registry login registry-1.docker.io --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin 
+      - name: Extract version from Git tag
+        id: get_version
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      - name: Package Helm Chart
+        run: |
+          helm package helm/scaphandre --version ${{ steps.get_version.outputs.VERSION }}
+      - name: Push Helm Chart as OCI Artifact
+        run: |
+          helm push ./scaphandre-${{ steps.get_version.outputs.VERSION }}.tgz oci://registry-1.docker.io/${{ secrets.DOCKERHUB_USERNAME }}

--- a/docs_src/tutorials/kubernetes.md
+++ b/docs_src/tutorials/kubernetes.md
@@ -6,12 +6,9 @@ Scaphandre, Prometheus and Grafana.
 ## Install Scaphandre
 
 First we install Scaphandre which runs as a daemon set which creates a pod on
-each node for collecting the metrics. The helm chart is not in a repo, it needs
-to be installed from the source code.
+each node for collecting the metrics.
 
-    git clone https://github.com/hubblo-org/scaphandre
-    cd scaphandre
-    helm install scaphandre helm/scaphandre
+    helm upgrade --install scaphandre oci://registry-1.docker.io/hubblo/scaphandre
 ### Parameters
 #### Service monitor parameters
 
@@ -52,6 +49,8 @@ You can access the Prometheus web UI by creating a port forwarding connection.
 
 Create a configmap to store the Grafana dashboard.
 
+    git clone https://github.com/hubblo-org/scaphandre
+    cd scaphandre
     kubectl create configmap scaphandre-dashboard \
         --from-file=scaphandre-dashboard.json=docs_src/tutorials/grafana-kubernetes-dashboard.json
 

--- a/helm/scaphandre/Chart.yaml
+++ b/helm/scaphandre/Chart.yaml
@@ -1,5 +1,4 @@
-apiVersion: v1
-appVersion: 0.1.1
+apiVersion: v2
 description: A Helm chart for Scaphandre electrical power consumption agent
 home: https://github.com/hubblo-org/scaphandre
 name: scaphandre


### PR DESCRIPTION
Fixes https://github.com/hubblo-org/scaphandre/issues/153

This adds a new workflow that will push the helm chart to Docker Hub as an OCI artifact. Example [run](https://github.com/rossf7/scaphandre/actions/runs/13309344027/job/37167707109)

Once there is a new release the chart can be installed with 

```
helm upgrade --install scaphandre oci://registry-1.docker.io/hubblo/scaphandre
```

I went with OCI instead of GitHub Pages because the chart releaser action is not able to add the chart tarball to existing releases. See https://github.com/helm/chart-releaser-action/issues/70


