### PR TITLE
fix: set fallback_scrape_protocol to enable scraping by prometheus 3.x

### DIFF
--- a/docker-compose/prom/prometheus.yml
+++ b/docker-compose/prom/prometheus.yml
@@ -34,5 +34,6 @@ scrape_configs:
 
     static_configs:
       - targets: ['scaphandre:8080']
+    fallback_scrape_protocol: PrometheusText0.0.4
 
 


### PR DESCRIPTION
The prometheus container runned with the docker-compose.yml was showing the following error:

`msg="Failed to determine correct type of scrape target." component="scrape manager" scrape_pool=scaphandre target=http://scaphandre:8080/metrics content_type="" fallback_media_type="" err="non-compliant scrape target sending blank Content-Type and no fallback_scrape_protocol specified for target"`

This was due to the fact that since version 3.x, prometheus needs to read a Content-Type alongside the metrics that specifies the scraping protocol to be used.

Adding the fallback_scrape_protocol fixes the problem but it probably would be a good idea to add a `Content-Type` too.