### PR TITLE
Fix container detection for cgroups v2 (Debian 13) - Fixes #420

### DIFF
--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -244,11 +244,11 @@ impl ProcessTracker {
     /// ```
     pub fn new(max_records_per_process: u16) -> ProcessTracker {
         #[cfg(feature = "containers")]
-        let regex_cgroup_docker = Regex::new(r"^(\d+::)?.*docker.*$").unwrap();
+        let regex_cgroup_docker = Regex::new(r"^(?:\d+::)?.*?/docker.*$").unwrap();
         #[cfg(feature = "containers")]
-        let regex_cgroup_kubernetes = Regex::new(r"^(\d+::)?/?kubepods.*$").unwrap();
+        let regex_cgroup_kubernetes = Regex::new(r"^(?:\d+::)?/?kubepods.*$").unwrap();
         #[cfg(feature = "containers")]
-        let regex_cgroup_containerd = Regex::new(r"^(\d+::)?.*containerd\.service.*$").unwrap();
+        let regex_cgroup_containerd = Regex::new(r"^(?:\d+::)?.*?/system\.slice/containerd\.service/.*$").unwrap();
 
         let mut system = System::new_all();
         system.refresh_cpu_specifics(CpuRefreshKind::everything());

--- a/src/sensors/utils.rs
+++ b/src/sensors/utils.rs
@@ -244,11 +244,11 @@ impl ProcessTracker {
     /// ```
     pub fn new(max_records_per_process: u16) -> ProcessTracker {
         #[cfg(feature = "containers")]
-        let regex_cgroup_docker = Regex::new(r"^.*/docker.*$").unwrap();
+        let regex_cgroup_docker = Regex::new(r"^(\d+::)?.*docker.*$").unwrap();
         #[cfg(feature = "containers")]
-        let regex_cgroup_kubernetes = Regex::new(r"^/kubepods.*$").unwrap();
+        let regex_cgroup_kubernetes = Regex::new(r"^(\d+::)?/?kubepods.*$").unwrap();
         #[cfg(feature = "containers")]
-        let regex_cgroup_containerd = Regex::new("/system.slice/containerd.service/.*$").unwrap();
+        let regex_cgroup_containerd = Regex::new(r"^(\d+::)?.*containerd\.service.*$").unwrap();
 
         let mut system = System::new_all();
         system.refresh_cpu_specifics(CpuRefreshKind::everything());


### PR DESCRIPTION
## Problem
Container detection returns null on cgroups v2 / Debian 13. When running Scaphandre with `--containers` flag on a system using cgroups v2 (like Debian 13), all containers have `container: null` in the JSON output.

## Root Cause
The container detection regex patterns don't account for the cgroups v2 path format. In cgroups v2, paths start with a hierarchy ID and `::` prefix (e.g., `0::/system.slice/docker-...`).

### Example cgroups v2 path:

0::/system.slice/docker-cb6970b7e0a606b4d7d25f4f0ef37a51efcd99a57c56d95c0a70bf645151bcd8.scope


## Solution
Updated regex patterns in `src/sensors/utils.rs` to handle both cgroups v1 and v2 formats by adding optional `(\d+::)?` prefix for cgroups v2 hierarchy IDs.

## Changes
- Docker regex: `^(\d+::)?.*docker.*$`
- Kubernetes regex: `^(\d+::)?/?kubepods.*$`
- Containerd regex: `^(\d+::)?.*containerd\.service.*$`

Fixes #420