### PR TITLE
Upgrade to Hyper 1_x and make serde_json non optional as used by stdout exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,9 +184,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "castaway"
@@ -496,7 +502,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c989c4ad66535edd02443e7d7699d3ab530df4523f12f6aeb7888bdc5ab7c32"
 dependencies = [
- "http",
+ "http 0.2.9",
  "isahc",
  "serde",
  "serde_derive",
@@ -549,7 +555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -630,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
@@ -660,24 +666,6 @@ name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
-
-[[package]]
-name = "futures-task"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
-
-[[package]]
-name = "futures-util"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
-]
 
 [[package]]
 name = "gethostname"
@@ -713,17 +701,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http",
- "indexmap 1.9.3",
+ "http 1.4.2",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -810,21 +798,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "0.4.5"
+name = "http"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
- "http",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.2",
+ "http-body",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -834,26 +844,39 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
- "http",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http 1.4.2",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
  "tokio",
  "tower-service",
- "tracing",
- "want",
 ]
 
 [[package]]
@@ -956,7 +979,7 @@ dependencies = [
  "encoding_rs",
  "event-listener",
  "futures-lite",
- "http",
+ "http 0.2.9",
  "log",
  "mime",
  "once_cell",
@@ -1005,7 +1028,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "http",
+ "http 0.2.9",
  "percent-encoding",
  "serde",
  "serde-value",
@@ -1022,7 +1045,7 @@ dependencies = [
  "base64",
  "chrono",
  "dirs",
- "http",
+ "http 0.2.9",
  "isahc",
  "k8s-openapi",
  "openssl",
@@ -1354,12 +1377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,7 +1644,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1683,7 +1700,9 @@ dependencies = [
  "ctrlc",
  "docker-sync",
  "hostname",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "isahc",
  "k8s-sync",
  "log",
@@ -1825,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ hyper-util = { version = "0.1.20", features = [
   "service",
 ], optional = true }
 http-body-util = { version = "0.1", optional = true }
-tokio = { version = "1.26.0", features = ["full"], optional = true}
-sysinfo = { version = "0.28.3"}
+tokio = { version = "1.26.0", features = ["full"], optional = true }
+sysinfo = { version = "0.28.3" }
 isahc = { version = "1.7.2", optional = true }
 ctrlc = { version = "3.4", features = ["termination"] }
 
@@ -59,7 +59,14 @@ core_affinity = { version = "0.8.1" }
 x86 = { version = "0.52.0" }
 
 [features]
-default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush"]
+default = [
+  "prometheus",
+  "riemann",
+  "warpten",
+  "json",
+  "containers",
+  "prometheuspush",
+]
 prometheus = ["hyper", "hyper-util", "http-body-util", "tokio"]
 riemann = ["riemann_client"]
 json = ["serde", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,15 @@ colored = "2.0"
 chrono = "0.4"
 docker-sync = { version = "0.1.2", optional = true }
 k8s-sync = { version = "0.2.3", optional = true }
-hyper = { version = "0.14", features = ["full"], optional = true }
-tokio = { version = "1.26.0", features = ["full"], optional = true }
-sysinfo = { version = "0.28.3" }
+hyper = { version = "1.10.1", features = ["full"], optional = true }
+hyper-util = { version = "0.1.20", features = [
+  "server-auto",
+  "server-graceful",
+  "service",
+], optional = true }
+http-body-util = { version = "0.1", optional = true }
+tokio = { version = "1.26.0", features = ["full"], optional = true}
+sysinfo = { version = "0.28.3"}
 isahc = { version = "1.7.2", optional = true }
 ctrlc = { version = "3.4", features = ["termination"] }
 
@@ -53,15 +59,8 @@ core_affinity = { version = "0.8.1" }
 x86 = { version = "0.52.0" }
 
 [features]
-default = [
-    "prometheus",
-    "warpten",
-    "json",
-    "containers",
-    "prometheuspush",
-    "qemu",
-]
-prometheus = ["hyper", "tokio"]
+default = ["prometheus", "riemann", "warpten", "json", "containers", "prometheuspush"]
+prometheus = ["hyper", "hyper-util", "http-body-util", "tokio"]
 riemann = ["riemann_client"]
 json = ["serde", "serde_json"]
 containers = ["docker-sync", "k8s-sync"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ regex = "1.7"
 riemann_client = { version = "1.0.0", optional = true }
 hostname = "0.3.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
-serde_json = { version = "1.0", optional = true }
+serde_json = "1.0"
 ordered-float = "2.0"
 warp10 = { version = "2.0.0", optional = true }
 time = "0.3"
@@ -69,7 +69,7 @@ default = [
 ]
 prometheus = ["hyper", "hyper-util", "http-body-util", "tokio"]
 riemann = ["riemann_client"]
-json = ["serde", "serde_json"]
+json = ["serde"]
 containers = ["docker-sync", "k8s-sync"]
 warpten = ["warp10"]
 prometheuspush = ["isahc"]

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -11,8 +11,11 @@ use crate::sensors::{Sensor, Topology};
 
 use chrono::Utc;
 use http_body_util::Full;
-use hyper::{body::Bytes, server::conn::http1, service::service_fn, Request, Response};
-use hyper_util::rt::TokioIo;
+use hyper::{body::Bytes, service::service_fn, Request, Response};
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo},
+    server::conn::auto::Builder,
+};
 
 use std::{
     collections::HashMap,
@@ -126,7 +129,6 @@ async fn run_server(
         .await
         .expect("Failed to bind to TcpListener");
 
-    let http = http1::Builder::new();
     let graceful = hyper_util::server::graceful::GracefulShutdown::new();
     let mut signal = std::pin::pin!(shutdown_signal());
 
@@ -135,13 +137,15 @@ async fn run_server(
             Ok((stream, _addr)) = listener.accept() => {
                 let ctx = context.clone();
                 let sfx = endpoint_suffix.to_string();
+                let watcher = graceful.watcher();
 
                 let io = TokioIo::new(stream);
-                let conn = http.serve_connection(io, service_fn(move |req| show_metrics(req, ctx.clone(), sfx.clone())));
 
-                let fut = graceful.watch(conn);
                 tokio::spawn(async move {
-                    if let Err(e) = fut.await {
+                    let http = Builder::new(TokioExecutor::new());
+                    let conn = http.serve_connection(io, service_fn(move |req| show_metrics(req, ctx.clone(), sfx.clone())));
+
+                    if let Err(e) = watcher.watch(conn).await {
                         warn!("Error serving connection: {:?}", e);
                     }
                 });

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -104,6 +104,13 @@ struct PowerMetrics {
     metric_generator: Mutex<MetricGenerator>,
 }
 
+async fn shutdown_signal() {
+    // Wait for the CTRL+C signal
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to install CTRL+C signal handler");
+}
+
 #[tokio::main]
 async fn run_server(
     socket_addr: SocketAddr,
@@ -119,27 +126,43 @@ async fn run_server(
         .await
         .expect("Failed to bind to TcpListener");
 
+    let http = http1::Builder::new();
+    let graceful = hyper_util::server::graceful::GracefulShutdown::new();
+    let mut signal = std::pin::pin!(shutdown_signal());
+
     loop {
-        let (tcp, _) = listener
-            .accept()
-            .await
-            .expect("Failed to accept an incoming connection");
-        let io = TokioIo::new(tcp);
+        tokio::select! {
+            Ok((stream, _addr)) = listener.accept() => {
+                let ctx = context.clone();
+                let sfx = endpoint_suffix.to_string();
 
-        let ctx = context.clone();
-        let sfx = endpoint_suffix.to_string();
+                let io = TokioIo::new(stream);
+                let conn = http.serve_connection(io, service_fn(move |req| show_metrics(req, ctx.clone(), sfx.clone())));
 
-        tokio::task::spawn(async move {
-            if let Err(err) = http1::Builder::new()
-                .serve_connection(
-                    io,
-                    service_fn(move |req| show_metrics(req, ctx.clone(), sfx.clone())),
-                )
-                .await
-            {
-                eprintln!("Error serving connection: {:?}", err);
+                let fut = graceful.watch(conn);
+                tokio::spawn(async move {
+                    if let Err(e) = fut.await {
+                        warn!("Error serving connection: {:?}", e);
+                    }
+                });
+
+            },
+
+            _ = &mut signal => {
+                drop(listener);
+                warn!("graceful shutdown signal received");
+                break;
             }
-        });
+        }
+    }
+
+    tokio::select! {
+        _ = graceful.shutdown() => {
+            warn!("all connections gracefully closed");
+        },
+        _ = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+            warn!("timed out wait for all connections to close");
+        }
     }
 }
 

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -11,6 +11,7 @@ use crate::sensors::{Sensor, Topology};
 
 use chrono::Utc;
 use http_body_util::Full;
+use hyper::header::CONTENT_TYPE;
 use hyper::{body::Bytes, service::service_fn, Request, Response};
 use hyper_util::{
     rt::{TokioExecutor, TokioIo},
@@ -272,7 +273,11 @@ async fn show_metrics(
             "<a href=\"https://github.com/hubblo-org/scaphandre/\">Scaphandre's</a> prometheus exporter here. Metrics available on <a href=\"/{suffix}\">/{suffix}</a>"
         );
     }
-    Ok(Response::new(body.into()))
+
+    Ok(Response::builder()
+        .header(CONTENT_TYPE, "text/plain; version=0.0.4")
+        .body(Full::new(Bytes::from(body)))
+        .expect("Failed to build Response"))
 }
 
 //  Copyright 2020 The scaphandre authors.

--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -8,17 +8,21 @@ use super::utils;
 use crate::exporters::{Exporter, MetricGenerator, MetricValueType};
 use crate::sensors::utils::current_system_time_since_epoch;
 use crate::sensors::{Sensor, Topology};
+
 use chrono::Utc;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Response, Server};
-use std::convert::Infallible;
+use http_body_util::Full;
+use hyper::{body::Bytes, server::conn::http1, service::service_fn, Request, Response};
+use hyper_util::rt::TokioIo;
+
 use std::{
     collections::HashMap,
+    convert::Infallible,
     fmt::Write,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{Arc, Mutex},
     time::Duration,
 };
+use tokio::net::TcpListener;
 
 /// Default ipv4/ipv6 address to expose the service is any
 const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
@@ -111,26 +115,32 @@ async fn run_server(
         metric_generator: Mutex::new(metric_generator),
     };
     let context = Arc::new(power_metrics);
-    let make_svc = make_service_fn(move |_| {
+    let listener = TcpListener::bind(socket_addr)
+        .await
+        .expect("Failed to bind to TcpListener");
+
+    loop {
+        let (tcp, _) = listener
+            .accept()
+            .await
+            .expect("Failed to accept an incoming connection");
+        let io = TokioIo::new(tcp);
+
         let ctx = context.clone();
         let sfx = endpoint_suffix.to_string();
-        async {
-            Ok::<_, Infallible>(service_fn(move |req| {
-                show_metrics(req, ctx.clone(), sfx.clone())
-            }))
-        }
-    });
-    let server = Server::bind(&socket_addr);
-    let res = server.serve(make_svc);
-    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-    let graceful = res.with_graceful_shutdown(async {
-        rx.await.ok();
-    });
 
-    if let Err(e) = graceful.await {
-        error!("server error: {}", e);
+        tokio::task::spawn(async move {
+            if let Err(err) = http1::Builder::new()
+                .serve_connection(
+                    io,
+                    service_fn(move |req| show_metrics(req, ctx.clone(), sfx.clone())),
+                )
+                .await
+            {
+                eprintln!("Error serving connection: {:?}", err);
+            }
+        });
     }
-    let _ = tx.send(());
 }
 
 /// Adds lines related to a metric in the body (String) of response.
@@ -152,10 +162,10 @@ fn push_metric(
 
 /// Handles requests and returns data formated for Prometheus.
 async fn show_metrics(
-    req: Request<Body>,
+    req: Request<hyper::body::Incoming>,
     context: Arc<PowerMetrics>,
     suffix: String,
-) -> Result<Response<Body>, Infallible> {
+) -> Result<Response<Full<Bytes>>, Infallible> {
     trace!("{}", req.uri());
     let mut body = String::new();
     if req.uri().path() == format!("/{}", suffix) {


### PR DESCRIPTION
We upgrade to a new hyper version, add graceful shutdown, http2 support.
Additionally, while trying to build scaphandre with `cargo b --features prometheus --no-default-features -r` I noticed that `serde_json` is not an optional dependency as the stdout exporter uses it in `raw_metrics_view` to format
the data if `raw_metrics` is used.

In order to properly work with Prometheus the `scrape_protocols` has to either be set by the server or in the client config. As we set it now in the server, the clients do not have to use the fix from [here](https://github.com/hubblo-org/scaphandre/issues/400#issuecomment-2508444059).

Closes #411
Closes #400