### PR TITLE
fix: qemu exporter undercounted virtiofs energy by ~5x

### DIFF
--- a/src/exporters/qemu.rs
+++ b/src/exporters/qemu.rs
@@ -56,7 +56,15 @@ impl QemuExporter {
         trace!("path: {}", path);
 
         self.topology.refresh();
-        if let Some(topo_energy) = self.topology.get_records_diff_power_microwatts() {
+        // Use the raw energy delta (in microjoules) between the last two records
+        // instead of get_records_diff_power_microwatts(), which returns an
+        // instantaneous power (microjoules / elapsed seconds). Reconstructing an
+        // energy value from that power would require multiplying back by the loop's
+        // step duration, which is easy to get wrong (see the bug this fixes) and
+        // drifts from the actual elapsed time whenever the loop is delayed (e.g. by
+        // scheduler jitter). get_records_diff() already reflects the real interval
+        // between the two refreshes, so it stays correct regardless of timing.
+        if let Some(topo_energy) = self.topology.get_records_diff() {
             let processes = self.topology.proc_tracker.get_alive_processes();
             let qemu_processes = QemuExporter::filter_qemu_vm_processes(&processes);
             for qp in qemu_processes {

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -428,7 +428,7 @@ impl Topology {
     /// between the last (in time) record from self.record_buffer and the previous one
     pub fn get_records_diff(&self) -> Option<Record> {
         let len = self.record_buffer.len();
-        if len > 2 {
+        if len > 1 {
             let last = self.record_buffer.last().unwrap();
             let previous = self.record_buffer.get(len - 2).unwrap();
             let last_value = last.value.parse::<u64>().unwrap();


### PR DESCRIPTION
## Summary
Fixes #428

- `QemuExporter::iterate()` wrote **power** (µW, from `get_records_diff_power_microwatts()`) directly into the virtiofs `energy_uj` counter as if it were **energy** (µJ), undercounting energy by a factor equal to the loop's step duration (~5x with the default 5s step). This made `scaph_host_power_microwatts` inside VMs report ~5x lower than the real power consumption — see #428 for the full root-cause analysis and measurements.
- Fix uses `Topology::get_records_diff()`, which returns the actual microjoule delta between the last two measurements, instead of reconstructing energy from power by multiplying back by an assumed step duration (fragile: breaks if a `--step` flag is ever added to the qemu subcommand, and drifts under scheduler jitter).
- Bonus fix: `get_records_diff()` required 3 records in the buffer (`len > 2`) before returning a value, even though it only reads the last two (`last` and `buffer[len-2]`). This is the only caller of that function, and delayed the first virtiofs energy write by one extra loop cycle after every exporter start. Aligned the check with the equivalent `get_records_diff_power_microwatts()` (`len > 1`).

## Test plan
- [x] `cargo test --features qemu` (`exporter_qemu` integration test)
- [x] Reproduced the ~5x undercount described in #428 and confirmed it's gone after this fix (virtiofs energy delta over a fixed window now matches `ratio% * host_power * elapsed_seconds`, see #428 for methodology)