### PR TITLE
#434 Prometheus exporter metrics freeze when scraped faster than the hardcoded 2s refresh throttle

### DIFF
--- a/src/exporters/prometheus.rs
+++ b/src/exporters/prometheus.rs
@@ -175,9 +175,9 @@ async fn show_metrics(
                                     .proc_tracker
                                     .clean_terminated_process_records_vectors();
                                 metric_generator.topology.refresh();
+                                *last_request = now;
                             }
                         }
-                        *last_request = now;
 
                         info!("{}: Refresh data", Utc::now().format("%Y-%m-%dT%H:%M:%S"));
 


### PR DESCRIPTION
This is a proposal for a minimal fix for the following issue: https://github.com/hubblo-org/scaphandre/issues/434